### PR TITLE
[FEAT] 대시보드 로직 연동 및 컴포넌트 분리

### DIFF
--- a/src/app/(with-navigation)/dashboard/_components/MemoList.tsx
+++ b/src/app/(with-navigation)/dashboard/_components/MemoList.tsx
@@ -5,10 +5,14 @@ import { useState } from 'react';
 
 import EmptyMemoImage from '@/assets/images/memo-empty.png';
 import PlusIcon from '@/components/icons/PlusIcon';
+import Memo from '@/components/memo/Memo';
 import TextEditorModal from '@/components/modal/text-editor';
 
 const MemoList = () => {
   const [openTextEditor, setOpenTextEditor] = useState(false);
+  const [memos, setMemos] = useState<
+    { title: string; memo: string; date: string }[]
+  >([]);
 
   return (
     <section className="shrink-0 min-w-[252px]">
@@ -23,26 +27,35 @@ const MemoList = () => {
         </button>
       </div>
 
-      {/* <div className="flex flex-col gap-3 mt-4">
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-              <Memo title="로열티 기획" memo="회원 등급, 포인트 시스템" date="7.12" />
-            </div> */}
-      <div className="w-[15.75rem] flex items-center flex-col gap-5 mt-[3.75rem]">
-        <p className="font-body-16 text-text-normal">남긴 메모가 없어요</p>
-        <Image src={EmptyMemoImage} width={100} height={100} alt="no memo" />
-      </div>
+      {memos.length > 0 ? (
+        <div className="flex flex-col gap-3 mt-4">
+          {memos.map((memo, index) => (
+            <Memo
+              key={index}
+              title={memo.title}
+              memo={memo.memo}
+              date={memo.date}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="w-[15.75rem] flex items-center flex-col gap-5 mt-[3.75rem]">
+          <p className="font-body-16 text-text-normal">남긴 메모가 없어요</p>
+          <Image src={EmptyMemoImage} width={100} height={100} alt="no memo" />
+        </div>
+      )}
 
       <TextEditorModal
         isOpen={openTextEditor}
-        onDismiss={() => setOpenTextEditor(false)}
+        onDismiss={() => {
+          setOpenTextEditor(false);
+        }}
+        onSaveText={(text) => {
+          setMemos((prev) => [
+            ...prev,
+            { title: '', memo: text, date: new Date().toLocaleDateString() },
+          ]);
+        }}
       />
     </section>
   );

--- a/src/app/(with-navigation)/dashboard/_components/Metrics.tsx
+++ b/src/app/(with-navigation)/dashboard/_components/Metrics.tsx
@@ -1,0 +1,46 @@
+import FireIcon from '@/components/icons/FireIcon';
+import FlagIcon from '@/components/icons/FlagIcon';
+import YellowFolderIcon from '@/components/icons/YellowFolderIcon';
+import { prefixZeros } from '@/utils/format';
+
+interface Props {
+  weekStreak: number;
+  reviewCount: number;
+  projectCount: number;
+}
+
+const Metrics = ({ weekStreak, reviewCount, projectCount }: Props) => {
+  return (
+    <section className="flex gap-3 w-full mb-7">
+      <div className="w-[19.5rem] pl-10 h-20 rounded-xl bg-surface-foregroundOn flex items-center gap-4">
+        <FireIcon size={32} />
+        <p className="font-body-16 text-text-strong">
+          <span className="font-chakra font-semibold italic mr-1">
+            {prefixZeros(weekStreak, 2)}
+          </span>
+          주 연속 회고
+        </p>
+      </div>
+      <div className="w-[19.5rem] pl-10 h-20 rounded-xl bg-surface-foregroundOn flex items-center gap-4">
+        <FlagIcon size={32} />
+        <p className="font-body-16 text-text-strong">
+          <span className="font-chakra font-semibold italic mr-1">
+            {prefixZeros(reviewCount, 2)}
+          </span>
+          개 회고 기록
+        </p>
+      </div>
+      <div className="w-[19.5rem] pl-10 h-20 rounded-xl bg-surface-foregroundOn flex items-center gap-4">
+        <YellowFolderIcon size={32} />
+        <p className="font-body-16 text-text-strong">
+          <span className="font-chakra font-semibold italic mr-1">
+            {prefixZeros(projectCount, 2)}
+          </span>
+          개 프로젝트
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default Metrics;

--- a/src/app/(with-navigation)/dashboard/_components/TodoList.tsx
+++ b/src/app/(with-navigation)/dashboard/_components/TodoList.tsx
@@ -1,94 +1,62 @@
 'use client';
 
 import Image from 'next/image';
+import { useState } from 'react';
 
 import EmptyTodoImage from '@/assets/images/todo-empty.png';
+import DeleteIcon from '@/components/icons/DeleteIcon';
 import PlusIcon from '@/components/icons/PlusIcon';
+import CheckboxInput from '@/components/inputs/checkbox/CheckboxInput';
 
 const TodoList = () => {
-  // const [todo, setTodo] = useState({
-  //   text: '',
-  //   checked: false,
-  // });
-  // const [todo2, setTodo2] = useState({
-  //   text: '',
-  //   checked: false,
-  // });
-  // const [todo3, setTodo3] = useState({
-  //   text: '',
-  //   checked: false,
-  // });
-  // const [todo4, setTodo4] = useState({
-  //   text: '',
-  //   checked: false,
-  // });
+  const [todos, setTodos] = useState<{ text: string; checked: boolean }[]>([]);
 
   return (
     <section className="w-full">
       <div className="flex items-center justify-between w-full">
         <p className="font-title-16 text-text-strong">이번 주 할 일</p>
-        <button className="button-line button-small">
+        <button
+          className="button-line button-small"
+          onClick={() =>
+            setTodos((prev) => [...prev, { text: '', checked: false }])
+          }
+        >
           <PlusIcon size={20} />
           <p className="font-body-13 text-text-strong">추가</p>
         </button>
       </div>
 
-      {/* <div className="flex flex-col gap-3 mt-4">
-              <CheckboxInput
-                value={todo.text}
-                checked={todo.checked}
-                onChange={(value) => setTodo((prev) => ({ ...prev, text: value }))}
-                onClickCheckbox={() => setTodo((prev) => ({ ...prev, checked: !prev.checked }))}
-                showButtonsOnHover
-                buttons={
-                  <button>
-                    <DeleteIcon size={20} />
-                  </button>
-                }
-              />
-              <CheckboxInput
-                value={todo2.text}
-                checked={todo2.checked}
-                onChange={(value) => setTodo2((prev) => ({ ...prev, text: value }))}
-                onClickCheckbox={() => setTodo2((prev) => ({ ...prev, checked: !prev.checked }))}
-                showButtonsOnHover
-                buttons={
-                  <button>
-                    <DeleteIcon size={20} />
-                  </button>
-                }
-              />
-              <CheckboxInput
-                value={todo3.text}
-                checked={todo3.checked}
-                onChange={(value) => setTodo3((prev) => ({ ...prev, text: value }))}
-                onClickCheckbox={() => setTodo3((prev) => ({ ...prev, checked: !prev.checked }))}
-                showButtonsOnHover
-                buttons={
-                  <button>
-                    <DeleteIcon size={20} />
-                  </button>
-                }
-              />
-              <CheckboxInput
-                value={todo4.text}
-                checked={todo4.checked}
-                onChange={(value) => setTodo4((prev) => ({ ...prev, text: value }))}
-                onClickCheckbox={() => setTodo4((prev) => ({ ...prev, checked: !prev.checked }))}
-                showButtonsOnHover
-                disabled
-                buttons={
-                  <button>
-                    <DeleteIcon size={20} />
-                  </button>
-                }
-              />
-            </div> */}
-
-      <div className="w-full flex items-center flex-col gap-5 mt-[3.75rem]">
-        <p className="font-body-16 text-text-normal">작성한 할 일이 없어요</p>
-        <Image src={EmptyTodoImage} width={100} height={100} alt="no memo" />
-      </div>
+      {todos.length > 0 ? (
+        <div className="flex flex-col gap-3 mt-4">
+          {todos.map((todo, index) => (
+            <CheckboxInput
+              key={index}
+              value={todo.text}
+              checked={todo.checked}
+              onChange={(value) =>
+                setTodos((prev) => ({ ...prev, text: value }))
+              }
+              onClickCheckbox={() =>
+                setTodos((prev) => ({ ...prev, checked: !todo.checked }))
+              }
+              buttons={
+                <button
+                  onClick={() =>
+                    setTodos((prev) => prev.filter((items) => items !== todo))
+                  }
+                >
+                  <DeleteIcon size={20} />
+                </button>
+              }
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="w-full flex items-center flex-col gap-5 mt-[3.75rem]">
+          <p className="font-body-16 text-text-normal">작성한 할 일이 없어요</p>
+          <Image src={EmptyTodoImage} width={100} height={100} alt="no memo" />
+        </div>
+      )}
     </section>
   );
 };

--- a/src/app/(with-navigation)/dashboard/_components/WeekNavigator.tsx
+++ b/src/app/(with-navigation)/dashboard/_components/WeekNavigator.tsx
@@ -1,0 +1,27 @@
+import ChevronLeft20Icon from '@/components/icons/ChevronLeft20Icon';
+import ChevronRight20Icon from '@/components/icons/ChevronRight20Icon';
+
+interface Props {
+  month: number;
+  week: number;
+}
+
+const WeekNavigator = ({ month, week }: Props) => {
+  return (
+    <div className="flex items-center gap-2">
+      <p className="font-head-20 text-text-strong">
+        {month}월 {week}주차
+      </p>
+      <div className="flex gap-1.5">
+        <button className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center">
+          <ChevronLeft20Icon size={20} />
+        </button>
+        <button className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center">
+          <ChevronRight20Icon size={20} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WeekNavigator;

--- a/src/app/(with-navigation)/dashboard/page.tsx
+++ b/src/app/(with-navigation)/dashboard/page.tsx
@@ -1,38 +1,14 @@
 import ChevronLeft20Icon from '@/components/icons/ChevronLeft20Icon';
 import ChevronRight20Icon from '@/components/icons/ChevronRight20Icon';
-import FireIcon from '@/components/icons/FireIcon';
-import FlagIcon from '@/components/icons/FlagIcon';
-import YellowFolderIcon from '@/components/icons/YellowFolderIcon';
 
 import MemoList from './_components/MemoList';
+import Metrics from './_components/Metrics';
 import TodoList from './_components/TodoList';
 
 export default function DashboardPage() {
   return (
     <div>
-      <section className="flex gap-3 w-full mb-7">
-        <div className="w-[19.5rem] pl-10 h-20 rounded-xl bg-surface-foregroundOn flex items-center gap-4">
-          <FireIcon size={32} />
-          <p className="font-body-16 text-text-strong">
-            <span className="font-chakra font-semibold italic mr-1">01</span>주
-            연속 회고
-          </p>
-        </div>
-        <div className="w-[19.5rem] pl-10 h-20 rounded-xl bg-surface-foregroundOn flex items-center gap-4">
-          <FlagIcon size={32} />
-          <p className="font-body-16 text-text-strong">
-            <span className="font-chakra font-semibold italic mr-1">04</span>개
-            회고 기록
-          </p>
-        </div>
-        <div className="w-[19.5rem] pl-10 h-20 rounded-xl bg-surface-foregroundOn flex items-center gap-4">
-          <YellowFolderIcon size={32} />
-          <p className="font-body-16 text-text-strong">
-            <span className="font-chakra font-semibold italic mr-1">29</span>개
-            프로젝트
-          </p>
-        </div>
-      </section>
+      <Metrics weekStreak={1} reviewCount={4} projectCount={26} />
 
       <div className="w-full">
         <section className="flex items-center justify-between mb-6">

--- a/src/app/(with-navigation)/dashboard/page.tsx
+++ b/src/app/(with-navigation)/dashboard/page.tsx
@@ -1,11 +1,9 @@
 import Link from 'next/link';
 
-import ChevronLeft20Icon from '@/components/icons/ChevronLeft20Icon';
-import ChevronRight20Icon from '@/components/icons/ChevronRight20Icon';
-
 import MemoList from './_components/MemoList';
 import Metrics from './_components/Metrics';
 import TodoList from './_components/TodoList';
+import WeekNavigator from './_components/WeekNavigator';
 
 export default function DashboardPage() {
   return (
@@ -14,17 +12,7 @@ export default function DashboardPage() {
 
       <div className="w-full">
         <section className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-2">
-            <p className="font-head-20 text-text-strong">6월 4주차</p>
-            <div className="flex gap-1.5">
-              <button className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center">
-                <ChevronLeft20Icon size={20} />
-              </button>
-              <button className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center">
-                <ChevronRight20Icon size={20} />
-              </button>
-            </div>
-          </div>
+          <WeekNavigator month={6} week={4} />
 
           <Link href="/review/step1">
             <button className="button-primary button-large">회고하기</button>

--- a/src/app/(with-navigation)/dashboard/page.tsx
+++ b/src/app/(with-navigation)/dashboard/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import ChevronLeft20Icon from '@/components/icons/ChevronLeft20Icon';
 import ChevronRight20Icon from '@/components/icons/ChevronRight20Icon';
 
@@ -24,7 +26,9 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          <button className="button-primary button-large">회고하기</button>
+          <Link href="/review/step1">
+            <button className="button-primary button-large">회고하기</button>
+          </Link>
         </section>
 
         <div className="flex gap-9">

--- a/src/components/modal/text-editor/index.tsx
+++ b/src/components/modal/text-editor/index.tsx
@@ -9,21 +9,36 @@ import MenuBar from '@/components/text-editor/MenuBar';
 import Modal from '../Modal';
 import { ModalProps } from '../ModalContainer';
 
-const TextEditorModal = (props: ModalProps) => {
+interface Props {
+  onSaveText: (text: string) => void;
+}
+
+const TextEditorModal = ({ onSaveText, ...rest }: ModalProps & Props) => {
   const editor = useEditor({
     extensions: [StarterKit, Underline],
     content: '<p>Hello World!</p>',
   });
 
   return (
-    <Modal closeIcon {...props}>
+    <Modal closeIcon {...rest}>
       <div className="h-[25rem] py-3.5 w-[28.5rem]">
         <div className="px-6 mb-2">
           <MenuBar editor={editor} />
         </div>
         <div className="w-full bg-line-assistive h-[1px]" />
         <div className="px-6 mt-4">
-          <EditorContent editor={editor} />
+          <EditorContent
+            editor={editor}
+            onKeyDown={(e) => {
+              if (
+                (e.ctrlKey && e.key === 'Enter') ||
+                (e.metaKey && e.key === 'Enter')
+              ) {
+                onSaveText(editor?.getText() ?? '');
+                rest.onDismiss?.();
+              }
+            }}
+          />
         </div>
       </div>
     </Modal>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,3 @@
+export const prefixZeros = (num: number, length: number) => {
+  return num.toString().padStart(length, '0');
+};


### PR DESCRIPTION
### 대시보드 로직 연동
이번주 할 일과 메모를 생성 및 삭제할 수 있도록 작업했습니다.

cf) 메모를 저장하는 방법은 ctrl + enter(맥의 경우에는 command + enter)를 누르면 됩니다.

### 컴포넌트 분리
컴포넌트를 분리했습니다. 혹시 넘기는 props가 이상한 점이 있다면 코멘트 부탁드립니다.

### 확인 필요한 사항
회고 기록이 현재는 2자리(??개) 까지만 고려되어 있는 것 같은데, 3자리 수가 되는 경우에는 어떻게 처리되어야 할지 문의를 해봐야 할 것 같아요.