### PR TITLE
[FEAT] 회고 페이지 로직 및 더미데이터 추가, 기타 공통 컴포넌트 수정

### DIFF
--- a/src/app/review/_components/add-button/AddButton.tsx
+++ b/src/app/review/_components/add-button/AddButton.tsx
@@ -8,7 +8,7 @@ import colors from '@/styles/colors';
 import { cn } from '@/utils/tailwind';
 
 import { currentTodoListAtom, nextTodoListAtom } from '../../stores';
-import { TodoListItem, WeekType } from '../../types';
+import { WeekType } from '../../types';
 
 interface Props {
   category: 'currentTodo' | 'nextTodo' | 'highLight' | 'lowLight';
@@ -24,18 +24,27 @@ export const AddButton = ({ category }: Props) => {
   const onClickAddButton = (category: Props['category']) => {
     const weekInfo = category.slice(0, -4);
 
-    const newItemValues: TodoListItem = {
-      week: weekInfo as WeekType,
-      isChecked: false,
-      todo: '',
-    };
-
     if (category === 'currentTodo') {
-      setCurrentTodoList((prev) => [...prev, newItemValues]);
+      setCurrentTodoList((prev) => [
+        ...prev,
+        {
+          id: `current-${prev.length + 1}`,
+          week: weekInfo as WeekType,
+          isChecked: false,
+          todo: '',
+        },
+      ]);
     } else if (category === 'nextTodo') {
-      setNextTodoList((prev) => [...prev, newItemValues]);
+      setNextTodoList((prev) => [
+        ...prev,
+        {
+          id: `current-${prev.length + 1}`,
+          week: weekInfo as WeekType,
+          isChecked: false,
+          todo: '',
+        },
+      ]);
     }
-    return;
   };
 
   return (

--- a/src/app/review/_components/add-button/AddButton.tsx
+++ b/src/app/review/_components/add-button/AddButton.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 
 import PlusIcon from '@/components/icons/PlusIcon';
 import colors from '@/styles/colors';
 import { cn } from '@/utils/tailwind';
+
+import { currentTodoListAtom, nextTodoListAtom } from '../../stores';
+import { TodoListItem, WeekType } from '../../types';
 
 interface Props {
   category: 'currentTodo' | 'nextTodo' | 'highLight' | 'lowLight';
@@ -12,8 +16,27 @@ interface Props {
 
 export const AddButton = ({ category }: Props) => {
   const [isHovered, setIsHovered] = useState(false);
+  const setCurrentTodoList = useSetAtom(currentTodoListAtom);
+  const setNextTodoList = useSetAtom(nextTodoListAtom);
 
   const isTodo = category === 'currentTodo' || category === 'nextTodo';
+
+  const onClickAddButton = (category: Props['category']) => {
+    const weekInfo = category.slice(0, -4);
+
+    const newItemValues: TodoListItem = {
+      week: weekInfo as WeekType,
+      isChecked: false,
+      todo: '',
+    };
+
+    if (category === 'currentTodo') {
+      setCurrentTodoList((prev) => [...prev, newItemValues]);
+    } else if (category === 'nextTodo') {
+      setNextTodoList((prev) => [...prev, newItemValues]);
+    }
+    return;
+  };
 
   return (
     <button
@@ -25,6 +48,7 @@ export const AddButton = ({ category }: Props) => {
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onClick={() => onClickAddButton(category)}
     >
       {isTodo ? (
         <PlusIcon size={20} stroke={colors.text.normal} />

--- a/src/app/review/_components/add-button/AddButton.tsx
+++ b/src/app/review/_components/add-button/AddButton.tsx
@@ -7,7 +7,13 @@ import PlusIcon from '@/components/icons/PlusIcon';
 import colors from '@/styles/colors';
 import { cn } from '@/utils/tailwind';
 
-import { currentTodoListAtom, nextTodoListAtom } from '../../stores';
+import { REVIEW_DEFAULT } from '../../dummy';
+import {
+  currentTodoListAtom,
+  highLightListAtom,
+  lowLightListAtom,
+  nextTodoListAtom,
+} from '../../stores';
 import { WeekType } from '../../types';
 
 interface Props {
@@ -18,32 +24,45 @@ export const AddButton = ({ category }: Props) => {
   const [isHovered, setIsHovered] = useState(false);
   const setCurrentTodoList = useSetAtom(currentTodoListAtom);
   const setNextTodoList = useSetAtom(nextTodoListAtom);
+  const setHighLightListAtom = useSetAtom(highLightListAtom);
+  const setLowLightListAtom = useSetAtom(lowLightListAtom);
 
   const isTodo = category === 'currentTodo' || category === 'nextTodo';
 
   const onClickAddButton = (category: Props['category']) => {
     const weekInfo = category.slice(0, -4);
 
-    if (category === 'currentTodo') {
-      setCurrentTodoList((prev) => [
-        ...prev,
-        {
-          id: `current-${prev.length + 1}`,
-          week: weekInfo as WeekType,
-          isChecked: false,
-          todo: '',
-        },
-      ]);
-    } else if (category === 'nextTodo') {
-      setNextTodoList((prev) => [
-        ...prev,
-        {
-          id: `current-${prev.length + 1}`,
-          week: weekInfo as WeekType,
-          isChecked: false,
-          todo: '',
-        },
-      ]);
+    switch (category) {
+      case 'currentTodo':
+        setCurrentTodoList((prev) => [
+          ...prev,
+          {
+            id: `current-${prev.length + 1}`,
+            week: weekInfo as WeekType,
+            isChecked: false,
+            todo: '',
+          },
+        ]);
+        break;
+      case 'nextTodo':
+        setNextTodoList((prev) => [
+          ...prev,
+          {
+            id: `next-${prev.length + 1}`,
+            week: weekInfo as WeekType,
+            isChecked: false,
+            todo: '',
+          },
+        ]);
+        break;
+      case 'highLight':
+        setHighLightListAtom((prev) => [...prev, REVIEW_DEFAULT]);
+        break;
+      case 'lowLight':
+        setLowLightListAtom((prev) => [...prev, REVIEW_DEFAULT]);
+        break;
+      default:
+        break;
     }
   };
 

--- a/src/app/review/_components/add-button/AddButton.tsx
+++ b/src/app/review/_components/add-button/AddButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useSetAtom } from 'jotai';
-import { useState } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
 
 import PlusIcon from '@/components/icons/PlusIcon';
 import colors from '@/styles/colors';
@@ -21,11 +21,14 @@ interface Props {
 }
 
 export const AddButton = ({ category }: Props) => {
-  const [isHovered, setIsHovered] = useState(false);
   const setCurrentTodoList = useSetAtom(currentTodoListAtom);
   const setNextTodoList = useSetAtom(nextTodoListAtom);
-  const setHighLightListAtom = useSetAtom(highLightListAtom);
-  const setLowLightListAtom = useSetAtom(lowLightListAtom);
+
+  const [highLightList, setHighLightList] = useAtom(highLightListAtom);
+  const [lowLightList, setLowLightList] = useAtom(lowLightListAtom);
+
+  const [isHovered, setIsHovered] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
 
   const isTodo = category === 'currentTodo' || category === 'nextTodo';
 
@@ -56,15 +59,24 @@ export const AddButton = ({ category }: Props) => {
         ]);
         break;
       case 'highLight':
-        setHighLightListAtom((prev) => [...prev, REVIEW_DEFAULT]);
+        setHighLightList((prev) => [...prev, REVIEW_DEFAULT]);
         break;
       case 'lowLight':
-        setLowLightListAtom((prev) => [...prev, REVIEW_DEFAULT]);
+        setLowLightList((prev) => [...prev, REVIEW_DEFAULT]);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    category === 'highLight' &&
+      highLightList.length >= 3 &&
+      setIsDisabled(true);
+    category === 'lowLight' && lowLightList.length >= 3 && setIsDisabled(true);
+  }, [category, highLightList, lowLightList]);
+
+  console.log(isDisabled);
 
   return (
     <button
@@ -73,10 +85,12 @@ export const AddButton = ({ category }: Props) => {
         isTodo
           ? 'button-text text-center'
           : 'button-line hover:bg-surface-blank hover:opacity-100',
+        isHovered ? 'text-text-neutral' : 'text-text-strong',
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={() => onClickAddButton(category)}
+      disabled={isDisabled}
     >
       {isTodo ? (
         <PlusIcon size={20} stroke={colors.text.normal} />
@@ -84,13 +98,13 @@ export const AddButton = ({ category }: Props) => {
         <div className="h-5 w-5 flex items-center justify-center">
           <PlusIcon
             size={15}
-            stroke={isHovered ? colors.text.neutral : colors.text.strong}
+            stroke={
+              isHovered || isDisabled ? colors.text.neutral : colors.text.strong
+            }
           />
         </div>
       )}
-      <p className={cn(isHovered ? 'text-text-neutral' : 'text-text-strong')}>
-        추가
-      </p>
+      추가
     </button>
   );
 };

--- a/src/app/review/_components/add-button/AddButton.tsx
+++ b/src/app/review/_components/add-button/AddButton.tsx
@@ -7,7 +7,6 @@ import PlusIcon from '@/components/icons/PlusIcon';
 import colors from '@/styles/colors';
 import { cn } from '@/utils/tailwind';
 
-import { REVIEW_DEFAULT } from '../../dummy';
 import {
   currentTodoListAtom,
   highLightListAtom,
@@ -59,10 +58,24 @@ export const AddButton = ({ category }: Props) => {
         ]);
         break;
       case 'highLight':
-        setHighLightList((prev) => [...prev, REVIEW_DEFAULT]);
+        setHighLightList((prev) => [
+          ...prev,
+          {
+            id: `highLight-${prev.length + 1}`,
+            text: '',
+            project: '',
+          },
+        ]);
         break;
       case 'lowLight':
-        setLowLightList((prev) => [...prev, REVIEW_DEFAULT]);
+        setLowLightList((prev) => [
+          ...prev,
+          {
+            id: `lowLight-${prev.length + 1}`,
+            text: '',
+            project: '',
+          },
+        ]);
         break;
       default:
         break;
@@ -75,8 +88,6 @@ export const AddButton = ({ category }: Props) => {
       setIsDisabled(true);
     category === 'lowLight' && lowLightList.length >= 3 && setIsDisabled(true);
   }, [category, highLightList, lowLightList]);
-
-  console.log(isDisabled);
 
   return (
     <button

--- a/src/app/review/_components/current-review/CurrentReview.tsx
+++ b/src/app/review/_components/current-review/CurrentReview.tsx
@@ -20,7 +20,7 @@ export const CurrentReview = ({ category }: Props) => {
         <AddButton category={category} />
       </div>
 
-      <CurrentReviewContainer />
+      <CurrentReviewContainer category={category} />
     </section>
   );
 };

--- a/src/app/review/_components/current-review/CurrentReviewContainer.tsx
+++ b/src/app/review/_components/current-review/CurrentReviewContainer.tsx
@@ -1,11 +1,26 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+
+import { highLightListAtom, lowLightListAtom } from '../../stores';
+import { ReviewType } from '../../types';
 import { CurrentReviewItem } from './CurrentReviewItem';
 
-export const CurrentReviewContainer = () => {
+export const CurrentReviewContainer = ({
+  category,
+}: {
+  category: ReviewType;
+}) => {
+  const highLightList = useAtomValue(highLightListAtom);
+  const lowLightList = useAtomValue(lowLightListAtom);
+
+  const reviewList = category === 'highLight' ? highLightList : lowLightList;
+
   return (
     <div className="w-full p-5 bg-surface-foreground rounded-xl flex flex-col gap-6 mb-3">
-      <CurrentReviewItem />
-      <CurrentReviewItem />
-      <CurrentReviewItem />
+      {reviewList.map((el, index) => (
+        <CurrentReviewItem key={index} category={category} {...el} />
+      ))}
     </div>
   );
 };

--- a/src/app/review/_components/current-review/CurrentReviewContainer.tsx
+++ b/src/app/review/_components/current-review/CurrentReviewContainer.tsx
@@ -19,7 +19,12 @@ export const CurrentReviewContainer = ({
   return (
     <div className="w-full p-5 bg-surface-foreground rounded-xl flex flex-col gap-6 mb-3">
       {reviewList.map((el, index) => (
-        <CurrentReviewItem key={index} category={category} {...el} />
+        <CurrentReviewItem
+          key={index}
+          category={category}
+          index={index}
+          {...el}
+        />
       ))}
     </div>
   );

--- a/src/app/review/_components/current-review/CurrentReviewItem.tsx
+++ b/src/app/review/_components/current-review/CurrentReviewItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Dropdown from '@/components/dropdown/Dropdown';
 import LinkIcon from '@/components/icons/LinkIcon';
@@ -18,6 +18,8 @@ interface Props extends ReviewListItem {
 export const CurrentReviewItem = ({ category, text, project }: Props) => {
   const projectList = useAtomValue(projectListAtom);
   const [reviewText, setReviewText] = useState(text);
+
+  useEffect(() => {}, []);
 
   return (
     <div className="flex flex-col gap-1">

--- a/src/app/review/_components/current-review/CurrentReviewItem.tsx
+++ b/src/app/review/_components/current-review/CurrentReviewItem.tsx
@@ -1,32 +1,44 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+import { useState } from 'react';
+
 import Dropdown from '@/components/dropdown/Dropdown';
 import LinkIcon from '@/components/icons/LinkIcon';
 import Textarea from '@/components/inputs/textarea/Textarea';
 
+import { projectListAtom } from '../../stores';
+import { ReviewListItem, ReviewType } from '../../types';
 import { DeleteButton } from '../delete-button/DeleteButton';
 
-export const CurrentReviewItem = () => {
+interface Props extends ReviewListItem {
+  category: ReviewType;
+}
+
+export const CurrentReviewItem = ({ category, text, project }: Props) => {
+  const projectList = useAtomValue(projectListAtom);
+  const [reviewText, setReviewText] = useState(text);
+
   return (
     <div className="flex flex-col gap-1">
       <div>
-        <Textarea className="min-h-[6.5rem]" />
+        <Textarea
+          className="min-h-[6.5rem]"
+          value={reviewText}
+          onChange={(val) => setReviewText(val)}
+        />
         <div className="flex">
           <LinkIcon size={36} />
-          <Dropdown id="hi" items={DROP_DUMMY} className="mt-2" />
+          <Dropdown
+            id={projectList['id']}
+            items={projectList['items']}
+            className="mt-2"
+            initialItem={project}
+          />
         </div>
       </div>
       {/* TODO: 에러 텍스트 추가 예정 */}
-      <DeleteButton />
+      <DeleteButton category={category} />
     </div>
   );
 };
-
-const DROP_DUMMY = [
-  {
-    name: 'test1',
-    value: 'test2',
-  },
-  {
-    name: 'test2',
-    value: 'test2',
-  },
-];

--- a/src/app/review/_components/current-review/CurrentReviewItem.tsx
+++ b/src/app/review/_components/current-review/CurrentReviewItem.tsx
@@ -3,13 +3,13 @@
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 
-import Dropdown from '@/components/dropdown/Dropdown';
 import LinkIcon from '@/components/icons/LinkIcon';
 import Textarea from '@/components/inputs/textarea/Textarea';
 
 import { projectListAtom } from '../../stores';
 import { ReviewListItem, ReviewType } from '../../types';
 import { DeleteButton } from '../delete-button/DeleteButton';
+import ProjectDropdown from '../project-dropdown/ProjectDropdown';
 
 interface Props extends ReviewListItem {
   category: ReviewType;
@@ -36,7 +36,7 @@ export const CurrentReviewItem = ({
         />
         <div className="flex">
           <LinkIcon size={36} />
-          <Dropdown
+          <ProjectDropdown
             id={projectList['id']}
             items={projectList['items']}
             className="mt-2"

--- a/src/app/review/_components/current-review/CurrentReviewItem.tsx
+++ b/src/app/review/_components/current-review/CurrentReviewItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import Dropdown from '@/components/dropdown/Dropdown';
 import LinkIcon from '@/components/icons/LinkIcon';
@@ -13,13 +13,18 @@ import { DeleteButton } from '../delete-button/DeleteButton';
 
 interface Props extends ReviewListItem {
   category: ReviewType;
+  index: number;
 }
 
-export const CurrentReviewItem = ({ category, text, project }: Props) => {
+export const CurrentReviewItem = ({
+  id,
+  category,
+  text,
+  project,
+  index,
+}: Props) => {
   const projectList = useAtomValue(projectListAtom);
   const [reviewText, setReviewText] = useState(text);
-
-  useEffect(() => {}, []);
 
   return (
     <div className="flex flex-col gap-1">
@@ -40,7 +45,7 @@ export const CurrentReviewItem = ({ category, text, project }: Props) => {
         </div>
       </div>
       {/* TODO: 에러 텍스트 추가 예정 */}
-      <DeleteButton category={category} />
+      {index !== 0 && <DeleteButton id={id} category={category} />}
     </div>
   );
 };

--- a/src/app/review/_components/delete-button/DeleteButton.tsx
+++ b/src/app/review/_components/delete-button/DeleteButton.tsx
@@ -1,6 +1,8 @@
 import DeleteIcon from '@/components/icons/DeleteIcon';
 
-export const DeleteButton = () => {
+import { ReviewType } from '../../types';
+
+export const DeleteButton = ({ category }: { category: ReviewType }) => {
   return (
     <div className="flex items-center h-8 gap-1 self-end">
       <DeleteIcon size={20} />

--- a/src/app/review/_components/delete-button/DeleteButton.tsx
+++ b/src/app/review/_components/delete-button/DeleteButton.tsx
@@ -1,12 +1,59 @@
-import DeleteIcon from '@/components/icons/DeleteIcon';
+import { useSetAtom } from 'jotai';
+import { useState } from 'react';
 
+import DeleteIcon from '@/components/icons/DeleteIcon';
+import Alert from '@/components/modal/Alert';
+
+import { highLightListAtom, lowLightListAtom } from '../../stores';
 import { ReviewType } from '../../types';
 
-export const DeleteButton = ({ category }: { category: ReviewType }) => {
+interface Props {
+  category: ReviewType;
+  id: string;
+}
+
+export const DeleteButton = ({ category, id }: Props) => {
+  const setHighLightList = useSetAtom(highLightListAtom);
+  const setLowLightList = useSetAtom(lowLightListAtom);
+  const [showDeleteAlert, setShowDeleteAlert] = useState(false);
+
+  const onClickDelete = () => {
+    if (category === 'highLight') {
+      setHighLightList((prev) => prev.filter((el) => el.id !== id));
+    } else {
+      setLowLightList((prev) => prev.filter((el) => el.id !== id));
+    }
+  };
+
   return (
-    <div className="flex items-center h-8 gap-1 self-end">
-      <DeleteIcon size={20} />
-      <p className="font-body-13 text-text-strong">삭제</p>
-    </div>
+    <>
+      <button
+        type="button"
+        className="flex items-center h-8 gap-1 self-end cursor-pointer"
+        onClick={() => setShowDeleteAlert(true)}
+      >
+        <DeleteIcon size={20} />
+        <p className="font-body-13 text-text-strong">삭제</p>
+      </button>
+
+      <Alert
+        isOpen={showDeleteAlert}
+        onDismiss={() => setShowDeleteAlert(false)}
+        title="정말로 삭제하시겠어요?"
+        buttons={{
+          left: {
+            text: '취소',
+            className:
+              'button-secondary button-medium font-body-14 text-text-strong',
+          },
+          right: {
+            text: '확인',
+            className:
+              'button-primary button-medium font-body-14 text-text-invert',
+            onClick: onClickDelete,
+          },
+        }}
+      />
+    </>
   );
 };

--- a/src/app/review/_components/last-review/LastReview.tsx
+++ b/src/app/review/_components/last-review/LastReview.tsx
@@ -1,17 +1,14 @@
+import { ReviewType } from '../../types';
 import { LastReviewContainer } from './LastReviewContainer';
 
-interface Props {
-  category: 'highLight' | 'lowLight';
-}
-
-export const LastReview = ({ category }: Props) => {
+export const LastReview = ({ category }: { category: ReviewType }) => {
   return (
     <section className="flex flex-col gap-3 mb-8">
       <p className="font-head-20 text-text-strong">
         지난주 {category === 'highLight' ? '하이라이트' : '로우라이트'}
       </p>
 
-      <LastReviewContainer />
+      <LastReviewContainer category={category} />
     </section>
   );
 };

--- a/src/app/review/_components/last-review/LastReviewContainer.tsx
+++ b/src/app/review/_components/last-review/LastReviewContainer.tsx
@@ -1,10 +1,22 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+
+import { lastHighLightListAtom, lastLowLightListAtom } from '../../stores';
+import { ReviewType } from '../../types';
 import { LastReviewItem } from './LastReviewItem';
 
-// TODO: map 받도록 수정 예정
-export const LastReviewContainer = () => {
+export const LastReviewContainer = ({ category }: { category: ReviewType }) => {
+  const lastHighLightList = useAtomValue(lastHighLightListAtom);
+  const lastLowLightList = useAtomValue(lastLowLightListAtom);
+
+  const list = category === 'highLight' ? lastHighLightList : lastLowLightList;
+
   return (
     <div className="flex flex-col gap-3">
-      <LastReviewItem />
+      {list.map((el, index) => (
+        <LastReviewItem key={index} {...el} />
+      ))}
     </div>
   );
 };

--- a/src/app/review/_components/last-review/LastReviewItem.tsx
+++ b/src/app/review/_components/last-review/LastReviewItem.tsx
@@ -1,20 +1,26 @@
 import LinkIcon from '@/components/icons/LinkIcon';
 import ProgressChip from '@/components/progress-chip/ProgressChip';
 
-export const LastReviewItem = () => {
+import { LastReviewListItem } from '../../types';
+
+export const LastReviewItem = ({
+  text,
+  project,
+  progressCount,
+}: LastReviewListItem) => {
   return (
     <div>
       <div
         className="relative w-full p-3 border border-line-assistive rounded-lg bg-surface-foreground
      font-body-14 text-text-strong"
       >
-        CurrentHighlight
+        {text}
       </div>
       <div className="flex">
         <LinkIcon size={36} />
         <div className="flex items-center gap-2 py-1.5 pl-3 pr-2 mt-2 border border-line-normal rounded-lg bg-surface-foregroundOn">
-          <p>차종, 시간대 등을 기반으로 예약 추천 기능 추가</p>
-          <ProgressChip percentage={50} />
+          <p>{project}</p>
+          <ProgressChip percentage={progressCount} />
         </div>
       </div>
     </div>

--- a/src/app/review/_components/project-dropdown/ProjectDropdown.tsx
+++ b/src/app/review/_components/project-dropdown/ProjectDropdown.tsx
@@ -1,0 +1,19 @@
+import PlusIcon from '@/components/icons/PlusIcon';
+import colors from '@/styles/colors';
+
+import Dropdown, {
+  DropdownProps,
+} from '../../../../components/dropdown/Dropdown';
+
+const ProjectDropdown = ({ ...rest }: DropdownProps) => {
+  return (
+    <Dropdown {...rest}>
+      <li className="h-[2.75rem] py-3 px-5 hover:bg-surface-background flex items-center gap-1 text-text-primary">
+        <PlusIcon size={16} stroke={colors.text.primary} />
+        새로운 프로젝트 추가
+      </li>
+    </Dropdown>
+  );
+};
+
+export default ProjectDropdown;

--- a/src/app/review/_components/tip/Tip.tsx
+++ b/src/app/review/_components/tip/Tip.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export const Tip = ({ category }: Props) => {
   return (
-    <div className="ml-5">
+    <div className="ml-5 mb-8">
       <p className="font-body-14 text-text-strong">
         {category === 'highLight' ? '하이라이트' : '로우라이트'} 작성 Tip
       </p>

--- a/src/app/review/_components/week-info/ActivePage.tsx
+++ b/src/app/review/_components/week-info/ActivePage.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+
+import ProgressDots from '@/components/progress-dots/ProgressDots';
+
+import { reviewPageAtom } from '../../stores';
+
+export const ActivePage = () => {
+  const activePage = useAtomValue(reviewPageAtom);
+
+  return (
+    <ProgressDots totalCount={3} activeCount={activePage} displayType="step" />
+  );
+};

--- a/src/app/review/_components/week-info/WeekInfo.tsx
+++ b/src/app/review/_components/week-info/WeekInfo.tsx
@@ -1,10 +1,12 @@
+import { ActivePage } from './ActivePage';
+
 export const WeekInfo = () => {
   return (
     <section className="flex justify-between items-center mb-6">
       <p className="font-head-24 text-text-strong">
-        6월 1주차<sup className="font-body-14 ml-2">6/3 ~ 6/7</sup>
+        7월 4주차<sup className="font-body-14 ml-2">7/21 ~ 7/27</sup>
       </p>
-      점 3개
+      <ActivePage />
     </section>
   );
 };

--- a/src/app/review/_components/week-info/WeekInfo.tsx
+++ b/src/app/review/_components/week-info/WeekInfo.tsx
@@ -4,7 +4,7 @@ export const WeekInfo = () => {
   return (
     <section className="flex justify-between items-center mb-6">
       <p className="font-head-24 text-text-strong">
-        7월 4주차<sup className="font-body-14 ml-2">7/22 ~ 7/29</sup>
+        7월 4주차<sup className="font-body-14 ml-2">7/22 ~ 7/26</sup>
       </p>
       <ActivePage />
     </section>

--- a/src/app/review/_components/week-info/WeekInfo.tsx
+++ b/src/app/review/_components/week-info/WeekInfo.tsx
@@ -4,7 +4,7 @@ export const WeekInfo = () => {
   return (
     <section className="flex justify-between items-center mb-6">
       <p className="font-head-24 text-text-strong">
-        7월 4주차<sup className="font-body-14 ml-2">7/21 ~ 7/27</sup>
+        7월 4주차<sup className="font-body-14 ml-2">7/22 ~ 7/29</sup>
       </p>
       <ActivePage />
     </section>

--- a/src/app/review/_components/weekly-memo/WeeklyMemo.tsx
+++ b/src/app/review/_components/weekly-memo/WeeklyMemo.tsx
@@ -1,13 +1,19 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+
 import Memo from '@/components/memo/Memo';
 
+import { memoListAtom } from '../../stores';
+
 const WeeklyMemo = () => {
+  const memoList = useAtomValue(memoListAtom);
+
   return (
     <div className="flex flex-col gap-3">
-      <Memo isBookmark memo="로열티 기획" date="7.12" />
-      <Memo isBookmark memo="로열티 기획" date="7.12" />
-      <Memo memo="로열티 기획" date="7.12" />
-      <Memo isBookmark memo="로열티 기획" date="7.12" />
-      <Memo memo="로열티 기획" date="7.12" />
+      {memoList.map((el, index) => (
+        <Memo key={index} {...el} />
+      ))}
     </div>
   );
 };

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -2,16 +2,21 @@ import { TodoListItem } from './types';
 
 export const CURRENT_TODO: TodoListItem[] = [
   {
+    id: 'current-1',
     week: 'current',
     isChecked: true,
     todo: '프로젝트 진행 상황 팔로업',
   },
   {
+    id: 'current-2',
+
     week: 'current',
     isChecked: false,
     todo: 'v1.2 기획분 요구사항 파악',
   },
   {
+    id: 'current-3',
+
     week: 'current',
     isChecked: false,
     todo: '디자인시스템 개발 일정 산정 및 공수 파악',
@@ -20,6 +25,7 @@ export const CURRENT_TODO: TodoListItem[] = [
 
 export const NEXT_TODO: TodoListItem[] = [
   {
+    id: 'next-1',
     week: 'next',
     isChecked: true,
     todo: '디자인시스템 input 관련 개발',

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -1,6 +1,6 @@
 import { DropdownProps } from '@/components/dropdown/Dropdown';
 
-import { MemoItem, TodoListItem } from './types';
+import { LastReviewListItem, MemoItem, TodoListItem } from './types';
 
 export const CURRENT_TODO: TodoListItem[] = [
   {
@@ -47,12 +47,16 @@ export const PROJECT_DROPDOWN: DropdownProps = {
       value: '',
     },
     {
-      name: '피트스탑 웹 서비스',
-      value: '피트스탑 웹 서비스',
+      name: '모멘투스 신규 서비스 기획',
+      value: '모멘투스 신규 서비스 기획',
     },
     {
-      name: '팀베라 개발환경 구축 프로젝트',
-      value: '팀베라 개발환경 구축 프로젝트',
+      name: '모멘텀 지표 리포팅',
+      value: '모멘텀 지표 리포팅',
+    },
+    {
+      name: '일하는 방식 최적화',
+      value: '일하는 방식 최적화',
     },
   ],
 };
@@ -78,5 +82,23 @@ export const MEMO_LIST: MemoItem[] = [
     title: '8/6 동기들이랑 점심 식사',
     memo: '참여자: 봉주, 지선, 해람, 호, 유림',
     date: '7.25',
+  },
+];
+
+export const LAST_HIGHLIGHT: LastReviewListItem[] = [
+  {
+    id: 'last-highlight-1',
+    text: '신규 서비스 기획 초기 방향성을 일찍 공유해서, 시간을 단축할 수 있었다.',
+    project: '모멘투스 신규 서비스 기획',
+    progressCount: 44,
+  },
+];
+
+export const LAST_LOWLIGHT: LastReviewListItem[] = [
+  {
+    id: 'last-lowlight-1',
+    text: '리더님한테 보고할 때 피그마보단 위키에 내용 정리해서 공유드리자..!',
+    project: '일하는 방식 최적화',
+    progressCount: 50,
   },
 ];

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -1,3 +1,5 @@
+import { DropdownProps } from '@/components/dropdown/Dropdown';
+
 import { TodoListItem } from './types';
 
 export const CURRENT_TODO: TodoListItem[] = [
@@ -31,3 +33,26 @@ export const NEXT_TODO: TodoListItem[] = [
     todo: '디자인시스템 input 관련 개발',
   },
 ];
+
+export const REVIEW_DEFAULT = {
+  text: '',
+  project: '',
+};
+
+export const PROJECT_DROPDOWN: DropdownProps = {
+  id: 'test-1',
+  items: [
+    {
+      name: '관련 프로젝트 선택',
+      value: '',
+    },
+    {
+      name: '피트스탑 웹 서비스',
+      value: '피트스탑 웹 서비스',
+    },
+    {
+      name: '팀베라 개발환경 구축 프로젝트',
+      value: '팀베라 개발환경 구축 프로젝트',
+    },
+  ],
+};

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -34,7 +34,14 @@ export const NEXT_TODO: TodoListItem[] = [
   },
 ];
 
-export const REVIEW_DEFAULT = {
+export const HIGHLIGHT_REVIEW = {
+  id: 'highLight-1',
+  text: '',
+  project: '',
+};
+
+export const LOW_LIGHT_REVIEW = {
+  id: 'lowLight-1',
   text: '',
   project: '',
 };

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -7,32 +7,25 @@ export const CURRENT_TODO: TodoListItem[] = [
     id: 'current-1',
     week: 'current',
     isChecked: true,
-    todo: '프로젝트 진행 상황 팔로업',
+    todo: '신규 서비스 기획서 작성 마무리',
   },
   {
     id: 'current-2',
 
     week: 'current',
     isChecked: false,
-    todo: 'v1.2 기획분 요구사항 파악',
+    todo: '경영진 보고 준비',
   },
   {
     id: 'current-3',
 
     week: 'current',
     isChecked: false,
-    todo: '디자인시스템 개발 일정 산정 및 공수 파악',
+    todo: '동기들과 점심 식사',
   },
 ];
 
-export const NEXT_TODO: TodoListItem[] = [
-  {
-    id: 'next-1',
-    week: 'next',
-    isChecked: true,
-    todo: '디자인시스템 input 관련 개발',
-  },
-];
+export const NEXT_TODO: TodoListItem[] = [];
 
 export const HIGHLIGHT_REVIEW = {
   id: 'highLight-1',
@@ -68,27 +61,22 @@ export const MEMO_LIST: MemoItem[] = [
   {
     id: 'memo-1',
     isBookmark: false,
-    title: '로열티 기획',
-    memo: '회원 등급, 포인트 시스템',
-    date: '7.12',
+    title: '신규 서비스 개요',
+    memo: `목표: 서비스 사용자 만족도 향상 및 체류 시간 증가\n주요 기능: 사용자 맞춤 추천, 실시간 알림 시스템, 사용자 피드백 통합`,
+    date: '7.22',
   },
   {
     id: 'memo-2',
-    isBookmark: false,
-    title: '제휴 브랜드 전용 새로운 테마, 템플릿 레퍼런스 찾기',
-    date: '7.12',
+    isBookmark: true,
+    title: '리더님 피드백',
+    memo: `유관 부서에 지표 리포트할 때 항상 엑셀 파일 첨부하기\n엑셀 제목은 데이터 날짜 항상 표기하기!`,
+    date: '7.24',
   },
   {
     id: 'memo-3',
     isBookmark: false,
-    title: '주간회의',
-    memo: `• 신규입사자 안내\n• a진행건 요약정리\n• 마케팅 팀 신규 캠페인 관련 공유`,
-    date: '7.12',
-  },
-  {
-    id: 'memo-4',
-    isBookmark: false,
-    memo: '개발팀에 서버 로그 재분석 요청 -> 롤백 계획 준비',
-    date: '7.12',
+    title: '8/6 동기들이랑 점심 식사',
+    memo: '참여자: 봉주, 지선, 해람, 호, 유림',
+    date: '7.25',
   },
 ];

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -1,6 +1,6 @@
 import { DropdownProps } from '@/components/dropdown/Dropdown';
 
-import { TodoListItem } from './types';
+import { MemoItem, TodoListItem } from './types';
 
 export const CURRENT_TODO: TodoListItem[] = [
   {
@@ -63,3 +63,32 @@ export const PROJECT_DROPDOWN: DropdownProps = {
     },
   ],
 };
+
+export const MEMO_LIST: MemoItem[] = [
+  {
+    id: 'memo-1',
+    isBookmark: false,
+    title: '로열티 기획',
+    memo: '회원 등급, 포인트 시스템',
+    date: '7.12',
+  },
+  {
+    id: 'memo-2',
+    isBookmark: false,
+    title: '제휴 브랜드 전용 새로운 테마, 템플릿 레퍼런스 찾기',
+    date: '7.12',
+  },
+  {
+    id: 'memo-3',
+    isBookmark: false,
+    title: '주간회의',
+    memo: `• 신규입사자 안내\n• a진행건 요약정리\n• 마케팅 팀 신규 캠페인 관련 공유`,
+    date: '7.12',
+  },
+  {
+    id: 'memo-4',
+    isBookmark: false,
+    memo: '개발팀에 서버 로그 재분석 요청 -> 롤백 계획 준비',
+    date: '7.12',
+  },
+];

--- a/src/app/review/dummy.ts
+++ b/src/app/review/dummy.ts
@@ -1,0 +1,27 @@
+import { TodoListItem } from './types';
+
+export const CURRENT_TODO: TodoListItem[] = [
+  {
+    week: 'current',
+    isChecked: true,
+    todo: '프로젝트 진행 상황 팔로업',
+  },
+  {
+    week: 'current',
+    isChecked: false,
+    todo: 'v1.2 기획분 요구사항 파악',
+  },
+  {
+    week: 'current',
+    isChecked: false,
+    todo: '디자인시스템 개발 일정 산정 및 공수 파악',
+  },
+];
+
+export const NEXT_TODO: TodoListItem[] = [
+  {
+    week: 'next',
+    isChecked: true,
+    todo: '디자인시스템 input 관련 개발',
+  },
+];

--- a/src/app/review/step1/_components/achievement/Score.tsx
+++ b/src/app/review/step1/_components/achievement/Score.tsx
@@ -1,13 +1,27 @@
 'use client';
 
+import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 
+import { pageButtonStatesAtom } from '@/app/review/stores';
 import ScorePicker from '@/components/score-picker/ScorePicker';
 
 export const Score = () => {
+  const setPageButtonStates = useSetAtom(pageButtonStatesAtom);
   const [selectedScore, setSelectedScore] = useState(0);
 
+  const onClickPickScore = (count: number) => {
+    setSelectedScore(count);
+
+    if (selectedScore > 0) {
+      setPageButtonStates((prev) => ({ ...prev, step1: true }));
+    }
+  };
+
   return (
-    <ScorePicker score={selectedScore} setScore={(e) => setSelectedScore(e)} />
+    <ScorePicker
+      score={selectedScore}
+      setScore={(score) => onClickPickScore(score)}
+    />
   );
 };

--- a/src/app/review/step1/_components/achievement/Score.tsx
+++ b/src/app/review/step1/_components/achievement/Score.tsx
@@ -12,10 +12,7 @@ export const Score = () => {
 
   const onClickPickScore = (count: number) => {
     setSelectedScore(count);
-
-    if (selectedScore > 0) {
-      setPageButtonStates((prev) => ({ ...prev, step1: true }));
-    }
+    setPageButtonStates((prev) => ({ ...prev, step1: true }));
   };
 
   return (

--- a/src/app/review/step1/_components/achievement/Score.tsx
+++ b/src/app/review/step1/_components/achievement/Score.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useSetAtom } from 'jotai';
-import { useState } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
 
-import { pageButtonStatesAtom } from '@/app/review/stores';
+import { pageButtonStatesAtom, scoreAtom } from '@/app/review/stores';
 import ScorePicker from '@/components/score-picker/ScorePicker';
 
 export const Score = () => {
   const setPageButtonStates = useSetAtom(pageButtonStatesAtom);
-  const [selectedScore, setSelectedScore] = useState(0);
+  const [selectedScore, setSelectedScore] = useAtom(scoreAtom);
 
   const onClickPickScore = (count: number) => {
     setSelectedScore(count);

--- a/src/app/review/step1/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step1/_components/paging-button/PagingButton.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import { useAtomValue } from 'jotai';
+
+import { pageButtonStatesAtom } from '@/app/review/stores';
 import { usePagingButton } from '@/app/review/utils';
 
 export const PagingButton = () => {
+  const pageButtonStates = useAtomValue(pageButtonStatesAtom);
+
   const { onClickPagingButton } = usePagingButton();
 
   return (
@@ -11,6 +16,7 @@ export const PagingButton = () => {
         type="button"
         className="button-primary button-large"
         onClick={() => onClickPagingButton({ path: 'step2', activePage: 2 })}
+        disabled={!pageButtonStates['step1']}
       >
         다음
       </button>

--- a/src/app/review/step1/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step1/_components/paging-button/PagingButton.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { usePagingButton } from '@/app/review/utils';
 
 export const PagingButton = () => {
-  const router = useRouter();
+  const { onClickPagingButton } = usePagingButton();
 
   return (
     <div className="flex justify-end">
       <button
         type="button"
         className="button-primary button-large"
-        onClick={() => router.push('/review/step2')}
+        onClick={() => onClickPagingButton({ path: 'step2', activePage: 2 })}
       >
         다음
       </button>

--- a/src/app/review/step1/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step1/_components/paging-button/PagingButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export const PagingButton = () => {
+  const router = useRouter();
+
+  return (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        className="button-primary button-large"
+        onClick={() => router.push('/review/step2')}
+      >
+        다음
+      </button>
+    </div>
+  );
+};

--- a/src/app/review/step1/_components/todo/Buttons.tsx
+++ b/src/app/review/step1/_components/todo/Buttons.tsx
@@ -1,13 +1,17 @@
 'use client';
 
+import { useSetAtom } from 'jotai';
+
+import { currentTodoListAtom, nextTodoListAtom } from '@/app/review/stores';
 import { WeekType } from '@/app/review/types';
 import DeleteIcon from '@/components/icons/DeleteIcon';
 
 interface Props {
   week: WeekType;
+  index: number;
 }
 
-export const MoveNextButton = ({ week }: Props) => {
+export const MoveNextButton = ({ week, index }: Props) => {
   return (
     <button
       type="button"
@@ -18,10 +22,21 @@ export const MoveNextButton = ({ week }: Props) => {
   );
 };
 
-export const DeleteButton = () => {
+export const DeleteButton = ({ week, index }: Props) => {
+  const setCurrentTodoList = useSetAtom(currentTodoListAtom);
+  const setNextTodoList = useSetAtom(nextTodoListAtom);
+
+  const onClickDelete = () => {
+    if (week === 'current') {
+      setCurrentTodoList((prev) => prev.filter((_, i) => i !== index));
+    } else {
+      setNextTodoList((prev) => prev.filter((_, i) => i !== index));
+    }
+  };
+
   return (
-    <button type="button">
-      <DeleteIcon />
+    <button type="button" onClick={onClickDelete}>
+      <DeleteIcon size={20} />
     </button>
   );
 };

--- a/src/app/review/step1/_components/todo/Buttons.tsx
+++ b/src/app/review/step1/_components/todo/Buttons.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import { WeekType } from '@/app/review/types';
 import DeleteIcon from '@/components/icons/DeleteIcon';
 
-export const MoveNextButton = ({ week }: { week: 'current' | 'next' }) => {
+interface Props {
+  week: WeekType;
+}
+
+export const MoveNextButton = ({ week }: Props) => {
   return (
     <button
       type="button"

--- a/src/app/review/step1/_components/todo/Buttons.tsx
+++ b/src/app/review/step1/_components/todo/Buttons.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useAtom, useSetAtom } from 'jotai';
+import { useState } from 'react';
 
 import { currentTodoListAtom, nextTodoListAtom } from '@/app/review/stores';
 import { WeekType } from '@/app/review/types';
 import DeleteIcon from '@/components/icons/DeleteIcon';
+import Alert from '@/components/modal/Alert';
 
 interface Props {
   week: WeekType;
@@ -46,6 +48,7 @@ export const MoveNextButton = ({ week, id }: Props) => {
 export const DeleteButton = ({ week, id }: Props) => {
   const setCurrentTodoList = useSetAtom(currentTodoListAtom);
   const setNextTodoList = useSetAtom(nextTodoListAtom);
+  const [showDeleteAlert, setShowDeleteAlert] = useState(false);
 
   const onClickDelete = () => {
     if (week === 'current') {
@@ -56,8 +59,29 @@ export const DeleteButton = ({ week, id }: Props) => {
   };
 
   return (
-    <button type="button" onClick={onClickDelete}>
-      <DeleteIcon size={20} />
-    </button>
+    <>
+      <button type="button" onClick={() => setShowDeleteAlert(true)}>
+        <DeleteIcon size={20} />
+      </button>
+
+      <Alert
+        isOpen={showDeleteAlert}
+        onDismiss={() => setShowDeleteAlert(false)}
+        title="정말로 삭제하시겠어요?"
+        buttons={{
+          left: {
+            text: '취소',
+            className:
+              'button-secondary button-medium font-body-14 text-text-strong',
+          },
+          right: {
+            text: '확인',
+            className:
+              'button-primary button-medium font-body-14 text-text-invert',
+            onClick: () => onClickDelete(),
+          },
+        }}
+      />
+    </>
   );
 };

--- a/src/app/review/step1/_components/todo/Buttons.tsx
+++ b/src/app/review/step1/_components/todo/Buttons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 
 import { currentTodoListAtom, nextTodoListAtom } from '@/app/review/stores';
 import { WeekType } from '@/app/review/types';
@@ -12,10 +12,32 @@ interface Props {
 }
 
 export const MoveNextButton = ({ week, id }: Props) => {
+  const [currentTodoList, setCurrentTodoList] = useAtom(currentTodoListAtom);
+  const [nextTodoList, setNextTodoList] = useAtom(nextTodoListAtom);
+
+  const onClickMove = () => {
+    if (week === 'current') {
+      const moveValues = currentTodoList.filter((el) => el.id === id)[0];
+      moveValues['week'] = 'next';
+      moveValues['isChecked'] = false;
+
+      setCurrentTodoList((prev) => prev.filter((el) => el.id !== id));
+      setNextTodoList((prev) => [...prev, moveValues]);
+    } else {
+      const moveValues = nextTodoList.filter((el) => el.id === id)[0];
+      moveValues['week'] = 'current';
+      moveValues['isChecked'] = false;
+
+      setNextTodoList((prev) => prev.filter((el) => el.id !== id));
+      setCurrentTodoList((prev) => [...prev, moveValues]);
+    }
+  };
+
   return (
     <button
       type="button"
       className="button-line button-small whitespace-nowrap"
+      onClick={() => onClickMove()}
     >
       {week === 'current' ? '다음주로 이동' : '되돌리기'}
     </button>

--- a/src/app/review/step1/_components/todo/Buttons.tsx
+++ b/src/app/review/step1/_components/todo/Buttons.tsx
@@ -4,16 +4,15 @@ import { useAtom, useSetAtom } from 'jotai';
 import { useState } from 'react';
 
 import { currentTodoListAtom, nextTodoListAtom } from '@/app/review/stores';
-import { WeekType } from '@/app/review/types';
+import { TodoListItem } from '@/app/review/types';
 import DeleteIcon from '@/components/icons/DeleteIcon';
 import Alert from '@/components/modal/Alert';
 
-interface Props {
-  week: WeekType;
-  id: string;
-}
-
-export const MoveNextButton = ({ week, id }: Props) => {
+export const MoveNextButton = ({
+  week,
+  id,
+  isMoved,
+}: Pick<TodoListItem, 'week' | 'id' | 'isMoved'>) => {
   const [currentTodoList, setCurrentTodoList] = useAtom(currentTodoListAtom);
   const [nextTodoList, setNextTodoList] = useAtom(nextTodoListAtom);
 
@@ -22,6 +21,7 @@ export const MoveNextButton = ({ week, id }: Props) => {
       const moveValues = currentTodoList.filter((el) => el.id === id)[0];
       moveValues['week'] = 'next';
       moveValues['isChecked'] = false;
+      moveValues['isMoved'] = true;
 
       setCurrentTodoList((prev) => prev.filter((el) => el.id !== id));
       setNextTodoList((prev) => [...prev, moveValues]);
@@ -29,11 +29,14 @@ export const MoveNextButton = ({ week, id }: Props) => {
       const moveValues = nextTodoList.filter((el) => el.id === id)[0];
       moveValues['week'] = 'current';
       moveValues['isChecked'] = false;
+      moveValues['isMoved'] = undefined;
 
       setNextTodoList((prev) => prev.filter((el) => el.id !== id));
       setCurrentTodoList((prev) => [...prev, moveValues]);
     }
   };
+
+  if (week === 'next' && !isMoved) return null;
 
   return (
     <button
@@ -45,7 +48,11 @@ export const MoveNextButton = ({ week, id }: Props) => {
     </button>
   );
 };
-export const DeleteButton = ({ week, id }: Props) => {
+
+export const DeleteButton = ({
+  week,
+  id,
+}: Pick<TodoListItem, 'week' | 'id'>) => {
   const setCurrentTodoList = useSetAtom(currentTodoListAtom);
   const setNextTodoList = useSetAtom(nextTodoListAtom);
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);

--- a/src/app/review/step1/_components/todo/Buttons.tsx
+++ b/src/app/review/step1/_components/todo/Buttons.tsx
@@ -8,10 +8,10 @@ import DeleteIcon from '@/components/icons/DeleteIcon';
 
 interface Props {
   week: WeekType;
-  index: number;
+  id: string;
 }
 
-export const MoveNextButton = ({ week, index }: Props) => {
+export const MoveNextButton = ({ week, id }: Props) => {
   return (
     <button
       type="button"
@@ -21,16 +21,15 @@ export const MoveNextButton = ({ week, index }: Props) => {
     </button>
   );
 };
-
-export const DeleteButton = ({ week, index }: Props) => {
+export const DeleteButton = ({ week, id }: Props) => {
   const setCurrentTodoList = useSetAtom(currentTodoListAtom);
   const setNextTodoList = useSetAtom(nextTodoListAtom);
 
   const onClickDelete = () => {
     if (week === 'current') {
-      setCurrentTodoList((prev) => prev.filter((_, i) => i !== index));
+      setCurrentTodoList((prev) => prev.filter((el) => el.id !== id));
     } else {
-      setNextTodoList((prev) => prev.filter((_, i) => i !== index));
+      setNextTodoList((prev) => prev.filter((el) => el.id !== id));
     }
   };
 

--- a/src/app/review/step1/_components/todo/ListItem.tsx
+++ b/src/app/review/step1/_components/todo/ListItem.tsx
@@ -2,19 +2,20 @@
 
 import { useState } from 'react';
 
+import { TodoListItem } from '@/app/review/types';
 import CheckboxInput from '@/components/inputs/checkbox/CheckboxInput';
 
 import { DeleteButton, MoveNextButton } from './Buttons';
 
-export const ListItem = ({ week }: { week: 'current' | 'next' }) => {
-  const [todo, setTodo] = useState('');
-  const [isCheck, setIsCheck] = useState(false);
+export const ListItem = ({ isChecked, todo, week }: TodoListItem) => {
+  const [text, setText] = useState(todo);
+  const [isCheck, setIsCheck] = useState(isChecked);
 
   return (
     <div className="h-12 flex items-center">
       <CheckboxInput
-        value={todo}
-        onChange={(val) => setTodo(val)}
+        value={text}
+        onChange={(val) => setText(val)}
         checked={isCheck}
         onClickCheckbox={() => setIsCheck((prev) => !prev)}
         category="review"

--- a/src/app/review/step1/_components/todo/ListItem.tsx
+++ b/src/app/review/step1/_components/todo/ListItem.tsx
@@ -7,7 +7,13 @@ import CheckboxInput from '@/components/inputs/checkbox/CheckboxInput';
 
 import { DeleteButton, MoveNextButton } from './Buttons';
 
-export const ListItem = ({ isChecked, todo, week, id }: TodoListItem) => {
+export const ListItem = ({
+  isChecked,
+  todo,
+  week,
+  id,
+  isMoved = false,
+}: TodoListItem) => {
   const [text, setText] = useState(todo);
   const [isCheck, setIsCheck] = useState(isChecked);
 
@@ -26,7 +32,7 @@ export const ListItem = ({ isChecked, todo, week, id }: TodoListItem) => {
         category="review"
       />
       <div className="flex items-center gap-2">
-        <MoveNextButton week={week} id={id} />
+        <MoveNextButton week={week} id={id} isMoved={isMoved} />
         <DeleteButton week={week} id={id} />
       </div>
     </div>

--- a/src/app/review/step1/_components/todo/ListItem.tsx
+++ b/src/app/review/step1/_components/todo/ListItem.tsx
@@ -1,19 +1,20 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { TodoListItem } from '@/app/review/types';
 import CheckboxInput from '@/components/inputs/checkbox/CheckboxInput';
 
 import { DeleteButton, MoveNextButton } from './Buttons';
 
-interface Props extends TodoListItem {
-  index: number;
-}
-
-export const ListItem = ({ isChecked, todo, week, index }: Props) => {
+export const ListItem = ({ isChecked, todo, week, id }: TodoListItem) => {
   const [text, setText] = useState(todo);
   const [isCheck, setIsCheck] = useState(isChecked);
+
+  useEffect(() => {
+    setText(todo);
+    setIsCheck(isChecked);
+  }, [todo, isChecked]);
 
   return (
     <div className="h-12 flex items-center">
@@ -25,8 +26,8 @@ export const ListItem = ({ isChecked, todo, week, index }: Props) => {
         category="review"
       />
       <div className="flex items-center gap-2">
-        <MoveNextButton week={week} index={index} />
-        <DeleteButton week={week} index={index} />
+        <MoveNextButton week={week} id={id} />
+        <DeleteButton week={week} id={id} />
       </div>
     </div>
   );

--- a/src/app/review/step1/_components/todo/ListItem.tsx
+++ b/src/app/review/step1/_components/todo/ListItem.tsx
@@ -7,7 +7,11 @@ import CheckboxInput from '@/components/inputs/checkbox/CheckboxInput';
 
 import { DeleteButton, MoveNextButton } from './Buttons';
 
-export const ListItem = ({ isChecked, todo, week }: TodoListItem) => {
+interface Props extends TodoListItem {
+  index: number;
+}
+
+export const ListItem = ({ isChecked, todo, week, index }: Props) => {
   const [text, setText] = useState(todo);
   const [isCheck, setIsCheck] = useState(isChecked);
 
@@ -21,8 +25,8 @@ export const ListItem = ({ isChecked, todo, week }: TodoListItem) => {
         category="review"
       />
       <div className="flex items-center gap-2">
-        <MoveNextButton week={week} />
-        <DeleteButton />
+        <MoveNextButton week={week} index={index} />
+        <DeleteButton week={week} index={index} />
       </div>
     </div>
   );

--- a/src/app/review/step1/_components/todo/TodoList.tsx
+++ b/src/app/review/step1/_components/todo/TodoList.tsx
@@ -20,7 +20,7 @@ export const TodoList = ({ week }: Props) => {
   return (
     <div className="flex flex-col">
       {todoList.map((el, index) => (
-        <ListItem key={index} index={index} {...el} />
+        <ListItem key={index} {...el} />
       ))}
     </div>
   );

--- a/src/app/review/step1/_components/todo/TodoList.tsx
+++ b/src/app/review/step1/_components/todo/TodoList.tsx
@@ -3,15 +3,11 @@
 import { useAtomValue } from 'jotai';
 
 import { currentTodoListAtom, nextTodoListAtom } from '@/app/review/stores';
-import { WeekType } from '@/app/review/types';
+import { TodoListItem } from '@/app/review/types';
 
 import { ListItem } from './ListItem';
 
-interface Props {
-  week: WeekType;
-}
-
-export const TodoList = ({ week }: Props) => {
+export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
   const currentTodoList = useAtomValue(currentTodoListAtom);
   const nextTodoList = useAtomValue(nextTodoListAtom);
 

--- a/src/app/review/step1/_components/todo/TodoList.tsx
+++ b/src/app/review/step1/_components/todo/TodoList.tsx
@@ -20,7 +20,7 @@ export const TodoList = ({ week }: Props) => {
   return (
     <div className="flex flex-col">
       {todoList.map((el, index) => (
-        <ListItem {...el} key={index} />
+        <ListItem key={index} index={index} {...el} />
       ))}
     </div>
   );

--- a/src/app/review/step1/_components/todo/TodoList.tsx
+++ b/src/app/review/step1/_components/todo/TodoList.tsx
@@ -1,14 +1,27 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+
+import { currentTodoListAtom, nextTodoListAtom } from '@/app/review/stores';
+import { WeekType } from '@/app/review/types';
+
 import { ListItem } from './ListItem';
 
-export const TodoList = ({ week }: { week: 'current' | 'next' }) => {
-  // week이 무엇인지에 따라 별도 로직 추가할 예정입니다.
+interface Props {
+  week: WeekType;
+}
+
+export const TodoList = ({ week }: Props) => {
+  const currentTodoList = useAtomValue(currentTodoListAtom);
+  const nextTodoList = useAtomValue(nextTodoListAtom);
+
+  const todoList = week === 'current' ? currentTodoList : nextTodoList;
+
   return (
     <div className="flex flex-col">
-      {/* 받아온 데이터에 맞춰 map으로 구현 */}
-      <ListItem week={week} />
-      <ListItem week={week} />
-      <ListItem week={week} />
-      <ListItem week={week} />
+      {todoList.map((el, index) => (
+        <ListItem {...el} key={index} />
+      ))}
     </div>
   );
 };

--- a/src/app/review/step1/page.tsx
+++ b/src/app/review/step1/page.tsx
@@ -6,7 +6,7 @@ export default function Step1Page() {
   return (
     <>
       <section className="flex flex-col gap-4 mb-10">
-        <p className="font-head-20 text-text-strong">6월 1주차는 어떠셨나요?</p>
+        <p className="font-head-20 text-text-strong">7월 4주차는 어떠셨나요?</p>
         <Achievement />
       </section>
 

--- a/src/app/review/step1/page.tsx
+++ b/src/app/review/step1/page.tsx
@@ -1,4 +1,5 @@
 import { Achievement } from './_components/achievement/Achievement';
+import { PagingButton } from './_components/paging-button/PagingButton';
 import { Todo } from './_components/todo/Todo';
 
 export default function Step1Page() {
@@ -9,12 +10,14 @@ export default function Step1Page() {
         <Achievement />
       </section>
 
-      <section className="flex flex-col gap-4">
+      <section className="flex flex-col gap-4 mb-8">
         <p className="font-head-20 text-text-strong">
           이번 주 한 일을 체크하고 다음 주를 계획해 보세요.
         </p>
         <Todo />
       </section>
+
+      <PagingButton />
     </>
   );
 }

--- a/src/app/review/step2/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step2/_components/paging-button/PagingButton.tsx
@@ -1,27 +1,24 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { usePagingButton } from '@/app/review/utils';
 
 export const PagingButton = () => {
-  const router = useRouter();
+  const { onClickPagingButton } = usePagingButton();
 
-  const onClickButton = (path: string) => {
-    router.push(`/review/${path}`);
-  };
   return (
     <div className="flex justify-end">
       <div className="flex justify-between gap-2.5">
         <button
           type="button"
           className="button-secondary button-large"
-          onClick={() => onClickButton('step1')}
+          onClick={() => onClickPagingButton({ path: 'step1', activePage: 1 })}
         >
           이전
         </button>
         <button
           type="button"
           className="button-primary button-large"
-          onClick={() => onClickButton('step3')}
+          onClick={() => onClickPagingButton({ path: 'step3', activePage: 3 })}
         >
           다음
         </button>

--- a/src/app/review/step2/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step2/_components/paging-button/PagingButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export const PagingButton = () => {
+  const router = useRouter();
+
+  const onClickButton = (path: string) => {
+    router.push(`/review/${path}`);
+  };
+  return (
+    <div className="flex justify-end">
+      <div className="flex justify-between gap-2.5">
+        <button
+          type="button"
+          className="button-secondary button-large"
+          onClick={() => onClickButton('step1')}
+        >
+          이전
+        </button>
+        <button
+          type="button"
+          className="button-primary button-large"
+          onClick={() => onClickButton('step3')}
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/review/step2/page.tsx
+++ b/src/app/review/step2/page.tsx
@@ -1,6 +1,7 @@
 import { CurrentReview } from '../_components/current-review/CurrentReview';
 import { LastReview } from '../_components/last-review/LastReview';
 import { Tip } from '../_components/tip/Tip';
+import { PagingButton } from './_components/paging-button/PagingButton';
 
 export default function Step2Page() {
   return (
@@ -8,6 +9,8 @@ export default function Step2Page() {
       <LastReview category="highLight" />
       <CurrentReview category="highLight" />
       <Tip category="highLight" />
+
+      <PagingButton />
     </>
   );
 }

--- a/src/app/review/step3/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step3/_components/paging-button/PagingButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export const PagingButton = () => {
+  const router = useRouter();
+
+  return (
+    <div className="flex justify-end">
+      <div className="flex justify-between gap-2.5">
+        <button
+          type="button"
+          className="button-secondary button-large"
+          onClick={() => router.push('/review/step2')}
+        >
+          이전
+        </button>
+        <button type="button" className="button-primary button-large">
+          등록
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/review/step3/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step3/_components/paging-button/PagingButton.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { usePagingButton } from '@/app/review/utils';
 
 export const PagingButton = () => {
-  const router = useRouter();
+  const { onClickPagingButton } = usePagingButton();
 
   return (
     <div className="flex justify-end">
@@ -11,7 +11,7 @@ export const PagingButton = () => {
         <button
           type="button"
           className="button-secondary button-large"
-          onClick={() => router.push('/review/step2')}
+          onClick={() => onClickPagingButton({ path: 'step2', activePage: 2 })}
         >
           이전
         </button>

--- a/src/app/review/step3/page.tsx
+++ b/src/app/review/step3/page.tsx
@@ -1,6 +1,7 @@
 import { CurrentReview } from '../_components/current-review/CurrentReview';
 import { LastReview } from '../_components/last-review/LastReview';
 import { Tip } from '../_components/tip/Tip';
+import { PagingButton } from './_components/paging-button/PagingButton';
 
 export default function Step3Page() {
   return (
@@ -8,6 +9,8 @@ export default function Step3Page() {
       <LastReview category="lowLight" />
       <CurrentReview category="lowLight" />
       <Tip category="lowLight" />
+
+      <PagingButton />
     </>
   );
 }

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -1,3 +1,10 @@
 import { atom } from 'jotai';
 
+import { CURRENT_TODO, NEXT_TODO } from './dummy';
+import { TodoListItem } from './types';
+
 export const reviewPageAtom = atom<number>(1);
+
+// FIXME: api 연동 후 더미 제거
+export const currentTodoListAtom = atom<TodoListItem[]>(CURRENT_TODO);
+export const nextTodoListAtom = atom<TodoListItem[]>(NEXT_TODO);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -30,3 +30,5 @@ export const lowLightListAtom = atom<ReviewListItem[]>([LOW_LIGHT_REVIEW]);
 
 export const projectListAtom = atom<DropdownProps>(PROJECT_DROPDOWN);
 export const memoListAtom = atom<MemoItem[]>(MEMO_LIST);
+
+export const scoreAtom = atom(0);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const reviewPageAtom = atom<number>(1);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -1,7 +1,14 @@
 import { atom } from 'jotai';
 
-import { CURRENT_TODO, NEXT_TODO } from './dummy';
-import { TodoListItem } from './types';
+import { DropdownProps } from '@/components/dropdown/Dropdown';
+
+import {
+  CURRENT_TODO,
+  NEXT_TODO,
+  PROJECT_DROPDOWN,
+  REVIEW_DEFAULT,
+} from './dummy';
+import { ReviewListItem, TodoListItem } from './types';
 
 // progressDots activeCount
 export const reviewPageAtom = atom(1);
@@ -16,3 +23,7 @@ export const pageButtonStatesAtom = atom({
 // FIXME: api 연동 후 더미 제거
 export const currentTodoListAtom = atom<TodoListItem[]>(CURRENT_TODO);
 export const nextTodoListAtom = atom<TodoListItem[]>(NEXT_TODO);
+export const highLightListAtom = atom<ReviewListItem[]>([REVIEW_DEFAULT]);
+export const lowLightListAtom = atom<ReviewListItem[]>([REVIEW_DEFAULT]);
+
+export const projectListAtom = atom<DropdownProps>(PROJECT_DROPDOWN);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -6,10 +6,11 @@ import {
   CURRENT_TODO,
   HIGHLIGHT_REVIEW,
   LOW_LIGHT_REVIEW,
+  MEMO_LIST,
   NEXT_TODO,
   PROJECT_DROPDOWN,
 } from './dummy';
-import { ReviewListItem, TodoListItem } from './types';
+import { MemoItem, ReviewListItem, TodoListItem } from './types';
 
 // progressDots activeCount
 export const reviewPageAtom = atom(1);
@@ -28,3 +29,4 @@ export const highLightListAtom = atom<ReviewListItem[]>([HIGHLIGHT_REVIEW]);
 export const lowLightListAtom = atom<ReviewListItem[]>([LOW_LIGHT_REVIEW]);
 
 export const projectListAtom = atom<DropdownProps>(PROJECT_DROPDOWN);
+export const memoListAtom = atom<MemoItem[]>(MEMO_LIST);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -3,7 +3,15 @@ import { atom } from 'jotai';
 import { CURRENT_TODO, NEXT_TODO } from './dummy';
 import { TodoListItem } from './types';
 
-export const reviewPageAtom = atom<number>(1);
+// progressDots activeCount
+export const reviewPageAtom = atom(1);
+
+// 페이지 이동 버튼 활성홭 여부
+export const pageButtonStatesAtom = atom({
+  step1: false,
+  step2: false,
+  step3: false,
+});
 
 // FIXME: api 연동 후 더미 제거
 export const currentTodoListAtom = atom<TodoListItem[]>(CURRENT_TODO);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -4,9 +4,10 @@ import { DropdownProps } from '@/components/dropdown/Dropdown';
 
 import {
   CURRENT_TODO,
+  HIGHLIGHT_REVIEW,
+  LOW_LIGHT_REVIEW,
   NEXT_TODO,
   PROJECT_DROPDOWN,
-  REVIEW_DEFAULT,
 } from './dummy';
 import { ReviewListItem, TodoListItem } from './types';
 
@@ -23,7 +24,7 @@ export const pageButtonStatesAtom = atom({
 // FIXME: api 연동 후 더미 제거
 export const currentTodoListAtom = atom<TodoListItem[]>(CURRENT_TODO);
 export const nextTodoListAtom = atom<TodoListItem[]>(NEXT_TODO);
-export const highLightListAtom = atom<ReviewListItem[]>([REVIEW_DEFAULT]);
-export const lowLightListAtom = atom<ReviewListItem[]>([REVIEW_DEFAULT]);
+export const highLightListAtom = atom<ReviewListItem[]>([HIGHLIGHT_REVIEW]);
+export const lowLightListAtom = atom<ReviewListItem[]>([LOW_LIGHT_REVIEW]);
 
 export const projectListAtom = atom<DropdownProps>(PROJECT_DROPDOWN);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -5,12 +5,19 @@ import { DropdownProps } from '@/components/dropdown/Dropdown';
 import {
   CURRENT_TODO,
   HIGHLIGHT_REVIEW,
+  LAST_HIGHLIGHT,
+  LAST_LOWLIGHT,
   LOW_LIGHT_REVIEW,
   MEMO_LIST,
   NEXT_TODO,
   PROJECT_DROPDOWN,
 } from './dummy';
-import { MemoItem, ReviewListItem, TodoListItem } from './types';
+import {
+  LastReviewListItem,
+  MemoItem,
+  ReviewListItem,
+  TodoListItem,
+} from './types';
 
 // progressDots activeCount
 export const reviewPageAtom = atom(1);
@@ -25,8 +32,11 @@ export const pageButtonStatesAtom = atom({
 // FIXME: api 연동 후 더미 제거
 export const currentTodoListAtom = atom<TodoListItem[]>(CURRENT_TODO);
 export const nextTodoListAtom = atom<TodoListItem[]>(NEXT_TODO);
+
 export const highLightListAtom = atom<ReviewListItem[]>([HIGHLIGHT_REVIEW]);
 export const lowLightListAtom = atom<ReviewListItem[]>([LOW_LIGHT_REVIEW]);
+export const lastHighLightListAtom = atom<LastReviewListItem[]>(LAST_HIGHLIGHT);
+export const lastLowLightListAtom = atom<LastReviewListItem[]>(LAST_LOWLIGHT);
 
 export const projectListAtom = atom<DropdownProps>(PROJECT_DROPDOWN);
 export const memoListAtom = atom<MemoItem[]>(MEMO_LIST);

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -13,6 +13,7 @@ export interface TodoListItem {
 }
 
 export interface ReviewListItem {
+  id: string;
   text: string;
   project: string;
 }

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -18,6 +18,10 @@ export interface ReviewListItem {
   project: string;
 }
 
+export interface LastReviewListItem extends ReviewListItem {
+  progressCount: number;
+}
+
 export interface MemoItem {
   id: string;
   isBookmark?: boolean;

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -1,13 +1,18 @@
+export type WeekType = 'current' | 'next';
+export type ReviewType = 'highLight' | 'lowLight';
 export interface PagingButtonProps {
   path: string;
   activePage: number;
 }
-
-export type WeekType = 'current' | 'next';
 export interface TodoListItem {
   week: WeekType;
   isChecked: boolean;
   todo: string;
   id: string;
   isMoved?: boolean;
+}
+
+export interface ReviewListItem {
+  text: string;
+  project: string;
 }

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -9,4 +9,5 @@ export interface TodoListItem {
   isChecked: boolean;
   todo: string;
   id: string;
+  isMoved?: boolean;
 }

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -17,3 +17,11 @@ export interface ReviewListItem {
   text: string;
   project: string;
 }
+
+export interface MemoItem {
+  id: string;
+  isBookmark?: boolean;
+  title?: string;
+  memo?: string; // TODO: 마크다운 적용 후 수정 필요
+  date: string; // FIXME: date 형식 조정 필요
+}

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -1,4 +1,11 @@
-export interface pagingButtonProps {
+export interface PagingButtonProps {
   path: string;
   activePage: number;
+}
+
+export type WeekType = 'current' | 'next';
+export interface TodoListItem {
+  week: WeekType;
+  isChecked: boolean;
+  todo: string;
 }

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -8,4 +8,5 @@ export interface TodoListItem {
   week: WeekType;
   isChecked: boolean;
   todo: string;
+  id: string;
 }

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -1,0 +1,4 @@
+export interface pagingButtonProps {
+  path: string;
+  activePage: number;
+}

--- a/src/app/review/utils.ts
+++ b/src/app/review/utils.ts
@@ -1,0 +1,23 @@
+import { useSetAtom } from 'jotai';
+import { useRouter } from 'next/navigation';
+
+import { reviewPageAtom } from './stores';
+
+interface onClickPagingButtonProps {
+  path: string;
+  activePage: number;
+}
+export const usePagingButton = () => {
+  const router = useRouter();
+  const setActivePage = useSetAtom(reviewPageAtom);
+
+  const onClickPagingButton = ({
+    path,
+    activePage,
+  }: onClickPagingButtonProps) => {
+    router.push(`/review/${path}`);
+    setActivePage(activePage);
+  };
+
+  return { onClickPagingButton };
+};

--- a/src/app/review/utils.ts
+++ b/src/app/review/utils.ts
@@ -2,19 +2,13 @@ import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
 import { reviewPageAtom } from './stores';
+import { pagingButtonProps } from './types';
 
-interface onClickPagingButtonProps {
-  path: string;
-  activePage: number;
-}
 export const usePagingButton = () => {
   const router = useRouter();
   const setActivePage = useSetAtom(reviewPageAtom);
 
-  const onClickPagingButton = ({
-    path,
-    activePage,
-  }: onClickPagingButtonProps) => {
+  const onClickPagingButton = ({ path, activePage }: pagingButtonProps) => {
     router.push(`/review/${path}`);
     setActivePage(activePage);
   };

--- a/src/app/review/utils.ts
+++ b/src/app/review/utils.ts
@@ -2,13 +2,13 @@ import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
 import { reviewPageAtom } from './stores';
-import { pagingButtonProps } from './types';
+import { PagingButtonProps } from './types';
 
 export const usePagingButton = () => {
   const router = useRouter();
   const setActivePage = useSetAtom(reviewPageAtom);
 
-  const onClickPagingButton = ({ path, activePage }: pagingButtonProps) => {
+  const onClickPagingButton = ({ path, activePage }: PagingButtonProps) => {
     router.push(`/review/${path}`);
     setActivePage(activePage);
   };

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { CSSProperties, HTMLAttributes, useEffect, useState } from 'react';
+import {
+  CSSProperties,
+  HTMLAttributes,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 
 import { cn } from '@/utils/tailwind';
 
@@ -23,8 +29,9 @@ const Dropdown = ({
   initialItem = '',
   items,
   className,
+  children,
   ...rest
-}: DropdownProps) => {
+}: PropsWithChildren<DropdownProps>) => {
   const [showOptions, setShowOptions] = useState(false);
   const [selectedValue, setSelectedValue] = useState(initialItem);
   const [selectedName, setSelectedName] = useState('');
@@ -73,6 +80,7 @@ const Dropdown = ({
               {item.name}
             </li>
           ))}
+          {children}
         </ul>
       )}
     </div>

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -1,37 +1,43 @@
 'use client';
 
-import { CSSProperties, HTMLAttributes, useState } from 'react';
+import { CSSProperties, HTMLAttributes, useEffect, useState } from 'react';
 
 import { cn } from '@/utils/tailwind';
 
 import ChevronDown20Icon from '../icons/ChevronDown20Icon';
 
-interface DropdownItem extends CSSProperties {
+export interface DropdownItem extends CSSProperties {
   name: string;
   value: string | number;
 }
 
-interface Props {
+export interface DropdownProps {
   id: string;
-  initialItem?: DropdownItem;
+  initialItem?: string | number;
   items: Array<DropdownItem>;
   className?: HTMLAttributes<HTMLDivElement>['className'];
 }
 
 const Dropdown = ({
   id,
-  initialItem = { name: '선택하세요', value: '' },
+  initialItem = '',
   items,
   className,
   ...rest
-}: Props) => {
+}: DropdownProps) => {
   const [showOptions, setShowOptions] = useState(false);
-  const [selectedItem, setSelectedItem] = useState(initialItem);
+  const [selectedValue, setSelectedValue] = useState(initialItem);
+  const [selectedName, setSelectedName] = useState('');
 
   const onClickItem = (item: DropdownItem) => {
-    setSelectedItem(item);
+    setSelectedValue(item.value);
     setShowOptions(false);
   };
+
+  useEffect(() => {
+    const defaultItem = items.filter((el) => el.value === selectedValue)[0];
+    setSelectedName(defaultItem?.name ?? '');
+  }, [items, selectedValue]);
 
   return (
     <div className={cn('relative w-full h-[2.75rem]', className)} {...rest}>
@@ -45,7 +51,7 @@ const Dropdown = ({
         disabled:bg-surface-base disabled:cursor-not-allowed disabled:hover:border-line-normal"
         onClick={() => setShowOptions((prev) => !prev)}
       >
-        <span>{selectedItem.name}</span>
+        <span>{selectedName}</span>
         <ChevronDown20Icon />
       </button>
 

--- a/src/components/inputs/textarea/Textarea.tsx
+++ b/src/components/inputs/textarea/Textarea.tsx
@@ -2,12 +2,14 @@ import { HTMLAttributes, TextareaHTMLAttributes } from 'react';
 
 import { cn } from '@/utils/tailwind';
 
-interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface Props
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'> {
   errorText?: string;
   className?: HTMLAttributes<HTMLTextAreaElement>['className'];
+  onChange?: (value: string) => void;
 }
 
-const Textarea = ({ errorText, className, ...rest }: Props) => {
+const Textarea = ({ errorText, className, onChange, ...rest }: Props) => {
   return (
     <>
       <textarea
@@ -20,6 +22,7 @@ const Textarea = ({ errorText, className, ...rest }: Props) => {
           className,
           errorText && 'border-state-negative outline-state-negative',
         )}
+        onChange={(e) => onChange?.(e.currentTarget.value)}
         {...rest}
       />
 

--- a/src/components/memo/Memo.tsx
+++ b/src/components/memo/Memo.tsx
@@ -1,13 +1,8 @@
+import { MemoItem } from '@/app/review/types';
+
 import MemoBottom from './MemoBottom';
 
-interface Props {
-  isBookmark?: boolean;
-  title?: string;
-  memo: string; // TODO: 마크다운 적용 후 수정 필요
-  date: string; // FIXME: date 형식 조정 필요
-}
-
-const Memo = ({ isBookmark = false, title, memo, date }: Props) => {
+const Memo = ({ isBookmark = false, title, memo, date, id }: MemoItem) => {
   return (
     <div
       className="w-[15.75rem] h-[8.75rem] rounded-lg pt-5 pr-4 pb-2.5 pl-5
@@ -24,11 +19,11 @@ const Memo = ({ isBookmark = false, title, memo, date }: Props) => {
           WebkitBoxOrient: 'vertical',
         }}
       >
-        {title && <p className="font-title-14 text-text-strong">{title}</p>}
-        <p className="font-body-14 text-text-strong">{memo}</p>
+        {!!title && <p className="font-title-14 text-text-strong">{title}</p>}
+        {!!memo && <p className="font-body-14 text-text-strong">{memo}</p>}
       </div>
 
-      <MemoBottom isBookmark={isBookmark} date={date} />
+      <MemoBottom id={id} isBookmark={isBookmark} date={date} />
     </div>
   );
 };

--- a/src/components/memo/MemoBottom.tsx
+++ b/src/components/memo/MemoBottom.tsx
@@ -1,28 +1,40 @@
 'use client';
 
+import { useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 
+import { memoListAtom } from '@/app/review/stores';
+import { MemoItem } from '@/app/review/types';
 import colors from '@/styles/colors';
 
 import BookmarkIcon from '../icons/BookmarkIcon';
 
-interface Props {
-  isBookmark: boolean;
-  date: string;
-}
-
-const MemoBottom = ({ isBookmark, date }: Props) => {
+const MemoBottom = ({
+  isBookmark,
+  date,
+  id,
+}: Pick<MemoItem, 'isBookmark' | 'date' | 'id'>) => {
   const [isMark, setIsMark] = useState(isBookmark);
+  const setMemoList = useSetAtom(memoListAtom);
 
   useEffect(() => {
     setIsMark(isBookmark);
   }, [isBookmark]);
 
+  const onClickBookmark = () => {
+    setIsMark((prev) => !prev);
+    setMemoList((prev) =>
+      prev.map((memo) =>
+        memo.id === id ? { ...memo, isBookmark: !memo.isBookmark } : memo,
+      ),
+    );
+  };
+
   return (
     <div className="w-full flex items-center justify-between">
       <p className="font-body-12 text-text-neutral">{date}</p>
       <BookmarkIcon
-        onClick={() => setIsMark((prev) => !prev)}
+        onClick={onClickBookmark}
         fill={isMark ? colors.line.focus : 'none'}
         stroke={isMark ? colors.line.focus : colors.text.neutral}
         className="cursor-pointer"

--- a/src/components/modal/Alert.tsx
+++ b/src/components/modal/Alert.tsx
@@ -21,7 +21,7 @@ interface Props extends ModalProps {
 const Alert = ({ title, content, buttons, ...rest }: Props) => {
   return (
     <ModalContainer {...rest}>
-      <div className="w-full h-full flex items-center justify-center z-30 relative animate-fade-up">
+      <div className="w-full h-full flex items-center justify-center z-30 relative">
         <div
           className="py-5 px-6 border border-line-normal relative rounded-[20px] bg-neutral-white min-w-[21.375rem] max-w-[36.625rem] min-h-[9.75rem] flex flex-col justify-between"
           style={{

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -74,7 +74,7 @@ const semanticColors = {
     primaryHover: '#4D4F52',
     secondary: '#E1E1E1',
     secondaryHover: '#CECECE',
-    disabled: '#EFEFEF',
+    disabled: '#F7F7F7',
   },
   state: {
     positive: '#43B000',


### PR DESCRIPTION
### 작업내용
- 회고 페이지 step1~step3 로직 작업했습니다
- atom, type, dummy 파일 review 디렉토리 내에 넣었는데 이상하다면 수정하겠습니다 !
- dummy는 데모데이용 데이터에 맞춰져 있습니다.

### 추가 변경사항
- button disabled 색상 변경
- alert fade-up애니메이션 이중으로 보이던 현상 수정
- dropdown initialValue 관련 로직 수정 (value만 넘기도록)
- dropdown에 children props 추가 (드랍다운 내에서 프로젝트 추가 등의 별도 동작 발생 가능하여 추가하였습니다)
- textarea 컴포넌트 onChange props 추가 (변경된 값 추적)


### 누락된 부분
- [ ] step2,3 : '새로운 프로젝트 추가' 클릭 시의 sheet
- [ ] step2,3 : input 자동 포커스 되는 부분 및 다음 버튼 클릭 여부
