### PR TITLE
[FEAT] api index 작성, proxy 설정, 로그인 개발

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // FIXME : 백에 localhost:3000 추가된 후 rewrites 삭제
+  async rewrites() {
+    return [
+      {
+        source: '/:path*',
+        destination: 'https://api-pitstop.site/:path*',
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
       },
     ];
   },
+
   async redirects() {
     return [
       {

--- a/src/apis/auth/login.ts
+++ b/src/apis/auth/login.ts
@@ -1,24 +1,28 @@
 import { typedPost } from '..';
+import { ErrorResponseType } from './../../types/apis';
 
 export const LOGIN_ERROR_MESSAGE: Record<string, string> = {
   incorrect_password: '비밀번호가 일치하지 않습니다.',
-  invalid_request: '이메일을 확인해주세요.',
+  resource_not_found: '이메일을 확인해주세요.',
 };
 
 export const login = async (email: string, password: string) => {
-  return typedPost<{ accessToken: string }>('/auth/sign-in', {
-    email,
-    password,
-  })
-    .then((res) => {
-      const accessToken = res.accessToken;
-      localStorage.setItem('accessToken', accessToken);
-      return { accessToken: accessToken };
-    })
-    .catch((err) => {
-      if ((err.code as string) && LOGIN_ERROR_MESSAGE[err.code]) {
-        return { errorMessage: LOGIN_ERROR_MESSAGE[err.code] };
-      }
-      return err;
+  try {
+    const res = await typedPost<{ accessToken: string }>('/auth/sign-in', {
+      email,
+      password,
     });
+
+    const accessToken = res.accessToken;
+    localStorage.setItem('accessToken', accessToken);
+
+    return { accessToken: accessToken };
+  } catch (err) {
+    const error = err as ErrorResponseType;
+
+    if ((error.code as string) && LOGIN_ERROR_MESSAGE[error.code]) {
+      return { errorMessage: LOGIN_ERROR_MESSAGE[error.code] };
+    }
+    return err;
+  }
 };

--- a/src/apis/auth/login.ts
+++ b/src/apis/auth/login.ts
@@ -23,6 +23,6 @@ export const login = async (email: string, password: string) => {
     if ((error.code as string) && LOGIN_ERROR_MESSAGE[error.code]) {
       return { errorMessage: LOGIN_ERROR_MESSAGE[error.code] };
     }
-    return err;
+    return { errorMessage: 'Unknown error' };
   }
 };

--- a/src/apis/auth/login.ts
+++ b/src/apis/auth/login.ts
@@ -1,0 +1,7 @@
+import { typedPost } from '..';
+
+type LoginResponseType = Awaited<typeof login>;
+
+export const login = (email: string, password: string) => {
+  return typedPost<LoginResponseType>('/auth/sign-in', { email, password });
+};

--- a/src/apis/auth/login.ts
+++ b/src/apis/auth/login.ts
@@ -1,7 +1,24 @@
 import { typedPost } from '..';
 
-type LoginResponseType = Awaited<typeof login>;
+export const LOGIN_ERROR_MESSAGE: Record<string, string> = {
+  incorrect_password: '비밀번호가 일치하지 않습니다.',
+  invalid_request: '이메일을 확인해주세요.',
+};
 
-export const login = (email: string, password: string) => {
-  return typedPost<LoginResponseType>('/auth/sign-in', { email, password });
+export const login = async (email: string, password: string) => {
+  return typedPost<{ accessToken: string }>('/auth/sign-in', {
+    email,
+    password,
+  })
+    .then((res) => {
+      const accessToken = res.accessToken;
+      localStorage.setItem('accessToken', accessToken);
+      return { accessToken: accessToken };
+    })
+    .catch((err) => {
+      if ((err.code as string) && LOGIN_ERROR_MESSAGE[err.code]) {
+        return { errorMessage: LOGIN_ERROR_MESSAGE[err.code] };
+      }
+      return err;
+    });
 };

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -2,7 +2,8 @@ import type { AxiosRequestConfig } from 'axios';
 import axios, { isAxiosError } from 'axios';
 
 const apiInstance = axios.create({
-  baseURL: 'https://api-pitstop.site',
+  // FIXME: 백에서 localhost:3000 등록 후 원래 도메인으로 변경
+  baseURL: '/',
   responseType: 'json',
 });
 
@@ -47,6 +48,7 @@ export const typedPost = async <T>(
   config?: AxiosRequestConfig,
 ) => {
   const response = await apiInstance.post<T>(url, data, config);
+  console.log('res', response);
   return response.data;
 };
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -48,7 +48,6 @@ export const typedPost = async <T>(
   config?: AxiosRequestConfig,
 ) => {
   const response = await apiInstance.post<T>(url, data, config);
-  console.log('res', response);
   return response.data;
 };
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,6 +1,8 @@
 import type { AxiosRequestConfig } from 'axios';
 import axios, { isAxiosError } from 'axios';
 
+import { ErrorResponseType } from '@/types/apis';
+
 const apiInstance = axios.create({
   // FIXME: 백에서 localhost:3000 등록 후 원래 도메인으로 변경
   baseURL: '/',
@@ -12,7 +14,7 @@ apiInstance.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('accessToken');
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+      config.headers.Authorization = token;
     }
     return config;
   },
@@ -26,10 +28,10 @@ apiInstance.interceptors.response.use(
   },
   (error) => {
     if (isAxiosError(error) && error.response) {
-      const errorResponse = {
+      const errorResponse: ErrorResponseType = {
         status: error.response.status,
         message: error.response.data?.message || 'An error occurred',
-        code: error.response.data?.code || 'UNKNOWN_ERROR',
+        code: error.response.data?.code || 'Unknown error',
       };
       return Promise.reject(errorResponse);
     }

--- a/src/app/(with-navigation)/layout.tsx
+++ b/src/app/(with-navigation)/layout.tsx
@@ -1,6 +1,5 @@
 import Header from '@/components/header/Header';
 import LeftNavigationBar from '@/components/navigation-bar/LeftNavigationBar';
-import ToastContainer from '@/components/toast/ToastContainer';
 
 export default function CommonLayout({
   children,
@@ -14,7 +13,6 @@ export default function CommonLayout({
       <div className="w-full h-full px-12 max-w-[1696px] min-w-[1440px] mx-auto pt-[3.75rem] relative">
         <LeftNavigationBar />
         <main className="flex justify-center ml-[132px]">{children}</main>
-        <ToastContainer />
       </div>
     </div>
   );

--- a/src/app/auth/login/components.tsx
+++ b/src/app/auth/login/components.tsx
@@ -21,7 +21,8 @@ const LoginComponents = () => {
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
+    const { name, value } = e.currentTarget;
+
     setFormData({
       ...formData,
       [name]: value,

--- a/src/app/auth/login/components.tsx
+++ b/src/app/auth/login/components.tsx
@@ -1,28 +1,52 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 import Input from '@/components/inputs/input/Input';
 import PasswordInput from '@/components/inputs/password/PasswordInput';
 
 const LoginComponents = () => {
   const router = useRouter();
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
 
   const onClickButton = (path: string) => {
     router.push(path);
   };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
+    });
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    // 로그인 후처리 필요
+  };
+
   return (
-    <div className="flex flex-col gap-7 w-[22.25rem]">
+    <form className="flex flex-col gap-7 w-[22.25rem]" onSubmit={handleSubmit}>
       <div className="flex flex-col gap-3">
-        <Input placeholder="이메일 주소" />
-        <PasswordInput placeholder="비밀번호" />
+        <Input
+          placeholder="이메일 주소"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+        />
+        <PasswordInput
+          placeholder="비밀번호"
+          name="password"
+          value={formData.password}
+          onChange={handleChange}
+        />
       </div>
       <div className="flex flex-col gap-3">
-        <button
-          type="button"
-          className="button-primary h-12 rounded-xl"
-          onClick={() => onClickButton('/')}
-        >
+        <button type="submit" className="button-primary h-12 rounded-xl">
           로그인
         </button>
         <button
@@ -33,7 +57,7 @@ const LoginComponents = () => {
           회원가입
         </button>
       </div>
-    </div>
+    </form>
   );
 };
 

--- a/src/app/auth/login/components.tsx
+++ b/src/app/auth/login/components.tsx
@@ -28,40 +28,49 @@ const LoginComponents = () => {
     });
   };
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    userLogin(formData.email, formData.password);
+    const login = await userLogin(formData.email, formData.password);
+
+    if (login === 'success') {
+      router.push('/');
+    }
   };
 
   return (
-    <form className="flex flex-col gap-7 w-[22.25rem]" onSubmit={handleSubmit}>
-      <div className="flex flex-col gap-3">
-        <Input
-          placeholder="이메일 주소"
-          name="email"
-          value={formData.email}
-          onChange={handleChange}
-        />
-        <PasswordInput
-          placeholder="비밀번호"
-          name="password"
-          value={formData.password}
-          onChange={handleChange}
-        />
-      </div>
-      <div className="flex flex-col gap-3">
-        <button type="submit" className="button-primary h-12 rounded-xl">
-          로그인
-        </button>
-        <button
-          type="button"
-          className="button-line h-12 rounded-xl"
-          onClick={() => onClickButton('/auth/sign-up')}
-        >
-          회원가입
-        </button>
-      </div>
-    </form>
+    <div>
+      <form
+        className="flex flex-col gap-7 w-[22.25rem]"
+        onSubmit={handleSubmit}
+      >
+        <div className="flex flex-col gap-3">
+          <Input
+            placeholder="이메일 주소"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+          />
+          <PasswordInput
+            placeholder="비밀번호"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="flex flex-col gap-3">
+          <button type="submit" className="button-primary h-12 rounded-xl">
+            로그인
+          </button>
+          <button
+            type="button"
+            className="button-line h-12 rounded-xl"
+            onClick={() => onClickButton('/auth/sign-up')}
+          >
+            회원가입
+          </button>
+        </div>
+      </form>
+    </div>
   );
 };
 

--- a/src/app/auth/login/components.tsx
+++ b/src/app/auth/login/components.tsx
@@ -5,9 +5,14 @@ import { ChangeEvent, FormEvent, useState } from 'react';
 
 import Input from '@/components/inputs/input/Input';
 import PasswordInput from '@/components/inputs/password/PasswordInput';
+import useToast from '@/hooks/useToast';
+import { useUser } from '@/hooks/useUser';
 
 const LoginComponents = () => {
   const router = useRouter();
+  const userLogin = useUser();
+  const { addToast } = useToast();
+
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -26,7 +31,8 @@ const LoginComponents = () => {
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    // 로그인 후처리 필요
+    e.preventDefault();
+    userLogin(formData.email, formData.password);
   };
 
   return (
@@ -49,6 +55,7 @@ const LoginComponents = () => {
         <button type="submit" className="button-primary h-12 rounded-xl">
           로그인
         </button>
+        
         <button
           type="button"
           className="button-line h-12 rounded-xl"

--- a/src/app/auth/login/components.tsx
+++ b/src/app/auth/login/components.tsx
@@ -5,13 +5,11 @@ import { ChangeEvent, FormEvent, useState } from 'react';
 
 import Input from '@/components/inputs/input/Input';
 import PasswordInput from '@/components/inputs/password/PasswordInput';
-import useToast from '@/hooks/useToast';
 import { useUser } from '@/hooks/useUser';
 
 const LoginComponents = () => {
   const router = useRouter();
   const userLogin = useUser();
-  const { addToast } = useToast();
 
   const [formData, setFormData] = useState({
     email: '',
@@ -55,7 +53,6 @@ const LoginComponents = () => {
         <button type="submit" className="button-primary h-12 rounded-xl">
           로그인
         </button>
-        
         <button
           type="button"
           className="button-line h-12 rounded-xl"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,8 @@ import type { Metadata } from 'next';
 import { Chakra_Petch } from 'next/font/google';
 import localFont from 'next/font/local';
 
+import ToastContainer from '@/components/toast/ToastContainer';
+
 const pretendard = localFont({
   src: '../assets/fonts/PretendardVariable.woff2',
   display: 'swap',
@@ -34,7 +36,10 @@ export default function RootLayout({
       lang="ko"
       className={`${pretendard.variable} ${chakraPetch.variable}`}
     >
-      <body className="font-pretendard bg-surface-background">{children}</body>
+      <body className="font-pretendard bg-surface-background">
+        {children}
+        <ToastContainer />
+      </body>
     </html>
   );
 }

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,12 +1,12 @@
 import { useSetAtom } from 'jotai';
 
 import { login } from '@/apis/auth/login';
-import { accessTokenAtom } from '@/stores/user/accessTokenAtom';
+import { userTokenAtom } from '@/stores/user/accessTokenAtom';
 
 import useToast from './useToast';
 
 export const useUser = () => {
-  const SetAccessToken = useSetAtom(accessTokenAtom);
+  const setUserToken = useSetAtom(userTokenAtom);
   const { addToast } = useToast();
 
   // login
@@ -14,7 +14,7 @@ export const useUser = () => {
     const result = await login(email, password);
 
     if (result.accessToken) {
-      SetAccessToken(result.accessToken);
+      setUserToken((prev) => ({ ...prev, accessToken: result.accessToken }));
       return 'success';
     } else if (result.errorMessage) {
       addToast({

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -15,12 +15,14 @@ export const useUser = () => {
 
     if (result.accessToken) {
       SetAccessToken(result.accessToken);
+      return 'success';
     } else if (result.errorMessage) {
       addToast({
         message: result.errorMessage,
         iconType: 'error',
       });
     }
+    return 'error';
   };
 
   return userLogin;

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,0 +1,27 @@
+import { useSetAtom } from 'jotai';
+
+import { login } from '@/apis/auth/login';
+import { accessTokenAtom } from '@/stores/user/accessTokenAtom';
+
+import useToast from './useToast';
+
+export const useUser = () => {
+  const SetAccessToken = useSetAtom(accessTokenAtom);
+  const { addToast } = useToast();
+
+  // login
+  const userLogin = async (email: string, password: string) => {
+    const result = await login(email, password);
+
+    if (result.accessToken) {
+      SetAccessToken(result.accessToken);
+    } else if (result.errorMessage) {
+      addToast({
+        message: result.errorMessage,
+        iconType: 'error',
+      });
+    }
+  };
+
+  return userLogin;
+};

--- a/src/stores/user/accessTokenAtom.ts
+++ b/src/stores/user/accessTokenAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const accessTokenAtom = atom<string | null>(null);

--- a/src/stores/user/accessTokenAtom.ts
+++ b/src/stores/user/accessTokenAtom.ts
@@ -1,3 +1,6 @@
 import { atom } from 'jotai';
 
-export const accessTokenAtom = atom<string | null>(null);
+export const userTokenAtom = atom({
+  accessToken: '',
+  refreshToken: '',
+});

--- a/src/types/apis.ts
+++ b/src/types/apis.ts
@@ -1,0 +1,5 @@
+export interface ErrorResponseType {
+  status: number;
+  message: string;
+  code: string;
+}


### PR DESCRIPTION
# 작업 내용
### API index 코드 추가
- 작성하신 코드에 `response intercepter` 덧붙여서, 정해진 에러코드가 돌아오는 경우 커스텀한 errorResponse로 반환합니다. (`Promise.reject` 임에 주의)

### proxy 설정
- CORS 에러로 당장 개발이 어려워 proxy 설정 추가했습니다.
-  next config, api index 확인해주시면 되고, 백에서 로컬호스트 추가 공지 전달 주면 수정하겠습니다.

### login api 개발
- apis에 `login` 함수 별도로 개발했습니다. 이곳에서 `accessToken`을 가져오는데 성공하면 `localStorage에 set`하고, 실패하면 `errorMessage`를 화면에 보여질 문구로 포맷하여 반환합니다.
- `useUser` 훅에서는 `login`에서 반환된 값을 활용합니다. `accessToken`이 반환되면 `toast Atom Setter`로 전역으로 관리되도록 하고, `errorMessage`가 반환되면 `toast`를 띄웁니다.
- login 컴포넌트의 onSubmit 핸들러에서는 useUser의 결과값으로 `router push`를 진행합니다.


# 추가 개발 사항
- 사이트 진입 시 localStorage에서 accessToken이 있다면 atom setter, 그렇지 않다면 로그인 페이지로 이동하는 로직은 차차 만들어 가겠습니다~