### PR TITLE
[FEAT] 프로젝트 페이지 api 연동

### DIFF
--- a/src/apis/get-dashboard/get.ts
+++ b/src/apis/get-dashboard/get.ts
@@ -2,13 +2,6 @@ import { CurrentWeek } from '@/types/currentWeek';
 
 import { typedGet } from '..';
 
-export const getDashboardData = async ({ year, month, week }: CurrentWeek) => {
-  const response = await typedGet<DashboardData>('/dashboard', {
-    params: { year, month, week },
-  });
-  return response;
-};
-
 export interface DashboardData {
   laps: number;
   daysLeft: number;
@@ -19,3 +12,10 @@ export interface DashboardData {
     content: string;
   }[];
 }
+
+export const getDashboardData = async ({ year, month, week }: CurrentWeek) => {
+  const response = await typedGet<DashboardData>('/dashboard', {
+    params: { year, month, week },
+  });
+  return response;
+};

--- a/src/apis/memo/get.ts
+++ b/src/apis/memo/get.ts
@@ -2,14 +2,6 @@ import { CurrentWeek } from '@/types/currentWeek';
 
 import { typedGet } from '..';
 
-export const getMemos = async ({ year, month, week }: CurrentWeek) => {
-  const response = await typedGet<Memo>('/memos', {
-    params: { year, month, week },
-  });
-
-  return response;
-};
-
 interface Memo {
   memos: {
     id: number;
@@ -17,3 +9,11 @@ interface Memo {
     isMarked: boolean;
   }[];
 }
+
+export const getMemos = async ({ year, month, week }: CurrentWeek) => {
+  const response = await typedGet<Memo>('/memos', {
+    params: { year, month, week },
+  });
+
+  return response;
+};

--- a/src/apis/projects/get.ts
+++ b/src/apis/projects/get.ts
@@ -1,4 +1,5 @@
 import { Highlight } from '@/types/highlight';
+import { Project } from '@/types/project';
 
 import { typedGet } from '..';
 
@@ -8,21 +9,16 @@ export const getProjectList = async () => {
 };
 
 export const getProject = async (id: number) => {
-  const response = await typedGet<Project>(`/projects/${id}`);
+  const response = await typedGet<ProjectResponse>(`/projects/${id}`);
   return response;
 };
 
 export interface ProjectList {
-  projects: Omit<Project, 'content'>[];
+  projects: Omit<ProjectResponse, 'content'>[];
 }
 
-export interface Project {
+export interface ProjectResponse extends Project {
   id: number;
-  title: string;
-  goal: string;
-  content: string;
-  startDate: string;
-  endDate: string;
   progress: number;
   highlights: Highlight[];
   lowlights: Highlight[];

--- a/src/apis/projects/get.ts
+++ b/src/apis/projects/get.ts
@@ -3,19 +3,14 @@ import { Project } from '@/types/project';
 
 import { typedGet } from '..';
 
+export interface ProjectList {
+  projects: Omit<ProjectResponse, 'content'>[];
+}
+
 export const getProjectList = async () => {
   const response = await typedGet<ProjectList>('/projects');
   return response;
 };
-
-export const getProject = async (id: number) => {
-  const response = await typedGet<ProjectResponse>(`/projects/${id}`);
-  return response;
-};
-
-export interface ProjectList {
-  projects: Omit<ProjectResponse, 'content'>[];
-}
 
 export interface ProjectResponse extends Project {
   id: number;
@@ -23,3 +18,8 @@ export interface ProjectResponse extends Project {
   highlights: Highlight[];
   lowlights: Highlight[];
 }
+
+export const getProject = async (id: number) => {
+  const response = await typedGet<ProjectResponse>(`/projects/${id}`);
+  return response;
+};

--- a/src/apis/projects/get.ts
+++ b/src/apis/projects/get.ts
@@ -1,3 +1,5 @@
+import { CurrentWeek } from '@/types/currentWeek';
+
 import { typedGet } from '..';
 
 export const getProjectList = async () => {
@@ -10,27 +12,26 @@ export const getProject = async ({ id }: { id: number | string }) => {
   return response;
 };
 
-interface ProjectList {
-  projects: Project[];
+export interface ProjectList {
+  projects: Omit<Project, 'content'>[];
 }
 
 export interface Project {
   id: number;
   title: string;
   goal: string;
+  content: string;
   startDate: [number, number, number];
   endDate: [number, number, number];
   progress: number;
-  // highlights: {
-  //   id: number;
-  //   content: string;
-  //   month: number;
-  //   week: number;
-  // }[];
-  // lowlights: {
-  //   id: number;
-  //   content: string;
-  //   month: number;
-  //   week: number;
-  // }[];
+  highlights: {
+    id: number;
+    content: string;
+    weekNumber: CurrentWeek;
+  }[];
+  lowlights: {
+    id: number;
+    content: string;
+    weekNumber: CurrentWeek;
+  }[];
 }

--- a/src/apis/projects/get.ts
+++ b/src/apis/projects/get.ts
@@ -1,4 +1,4 @@
-import { CurrentWeek } from '@/types/currentWeek';
+import { Highlight } from '@/types/highlight';
 
 import { typedGet } from '..';
 
@@ -24,14 +24,6 @@ export interface Project {
   startDate: string;
   endDate: string;
   progress: number;
-  highlights: {
-    id: number;
-    content: string;
-    weekNumber: CurrentWeek;
-  }[];
-  lowlights: {
-    id: number;
-    content: string;
-    weekNumber: CurrentWeek;
-  }[];
+  highlights: Highlight[];
+  lowlights: Highlight[];
 }

--- a/src/apis/projects/get.ts
+++ b/src/apis/projects/get.ts
@@ -7,7 +7,7 @@ export const getProjectList = async () => {
   return response;
 };
 
-export const getProject = async ({ id }: { id: number | string }) => {
+export const getProject = async (id: number) => {
   const response = await typedGet<Project>(`/projects/${id}`);
   return response;
 };

--- a/src/apis/projects/get.ts
+++ b/src/apis/projects/get.ts
@@ -21,8 +21,8 @@ export interface Project {
   title: string;
   goal: string;
   content: string;
-  startDate: [number, number, number];
-  endDate: [number, number, number];
+  startDate: string;
+  endDate: string;
   progress: number;
   highlights: {
     id: number;

--- a/src/apis/projects/post.ts
+++ b/src/apis/projects/post.ts
@@ -1,0 +1,13 @@
+import { typedPost } from '..';
+
+export const addProject = async (body: AddProjectRequest) => {
+  const response = await typedPost('/project', body);
+  return response;
+};
+
+interface AddProjectRequest {
+  title: string;
+  startDate: string;
+  endDate: string;
+  goal: string;
+}

--- a/src/apis/projects/post.ts
+++ b/src/apis/projects/post.ts
@@ -1,13 +1,8 @@
+import { Project } from '@/types/project';
+
 import { typedPost } from '..';
 
-export const addProject = async (body: AddProjectRequest) => {
+export const addProject = async (body: Project) => {
   const response = await typedPost('/project', body);
   return response;
 };
-
-interface AddProjectRequest {
-  title: string;
-  startDate: string;
-  endDate: string;
-  goal: string;
-}

--- a/src/apis/projects/put.ts
+++ b/src/apis/projects/put.ts
@@ -1,14 +1,8 @@
+import { Project } from '@/types/project';
+
 import { typedPut } from '..';
 
-export const editProject = async (id: number, body: EditProjectResponse) => {
+export const editProject = async (id: number, body: Project) => {
   const response = await typedPut(`/projects/${id}`, body);
   return response;
 };
-
-interface EditProjectResponse {
-  title: string;
-  startDate: string;
-  endDate: string;
-  goal: string;
-  content: string;
-}

--- a/src/apis/projects/put.ts
+++ b/src/apis/projects/put.ts
@@ -1,0 +1,14 @@
+import { typedPut } from '..';
+
+export const editProject = async (id: number, body: EditProjectResponse) => {
+  const response = await typedPut(`/projects/${id}`, body);
+  return response;
+};
+
+interface EditProjectResponse {
+  title: string;
+  startDate: string;
+  endDate: string;
+  goal: string;
+  content: string;
+}

--- a/src/app/(with-navigation)/project/_components/project-item/ProjectItem.tsx
+++ b/src/app/(with-navigation)/project/_components/project-item/ProjectItem.tsx
@@ -31,7 +31,7 @@ const ProjectItem = ({ id, title, progress }: Props) => {
       </div>
 
       <ProjectDetailSheet
-        projectId={1}
+        projectId={id}
         isOpen={showSheet}
         closeSheet={() => setShowSheet(false)}
       />

--- a/src/app/(with-navigation)/project/_components/project-item/ProjectItem.tsx
+++ b/src/app/(with-navigation)/project/_components/project-item/ProjectItem.tsx
@@ -9,9 +9,10 @@ interface Props {
   id: number;
   title: string;
   progress: number;
+  onClose?: () => void;
 }
 
-const ProjectItem = ({ id, title, progress }: Props) => {
+const ProjectItem = ({ id, title, progress, onClose }: Props) => {
   const [showSheet, setShowSheet] = useState(false);
 
   return (
@@ -33,7 +34,10 @@ const ProjectItem = ({ id, title, progress }: Props) => {
       <ProjectDetailSheet
         projectId={id}
         isOpen={showSheet}
-        closeSheet={() => setShowSheet(false)}
+        closeSheet={() => {
+          onClose?.();
+          setShowSheet(false);
+        }}
       />
     </>
   );

--- a/src/app/(with-navigation)/project/page.tsx
+++ b/src/app/(with-navigation)/project/page.tsx
@@ -18,8 +18,6 @@ export default function ProjectPage() {
   const getProjects = async () => {
     const { projects } = await getProjectList();
     setProjects(projects);
-
-    console.log(projects);
   };
 
   return (

--- a/src/app/(with-navigation)/project/page.tsx
+++ b/src/app/(with-navigation)/project/page.tsx
@@ -33,6 +33,7 @@ export default function ProjectPage() {
                 id={project.id}
                 title={project.title}
                 progress={project.progress}
+                onClose={getProjects}
               />
             ))}
           </>

--- a/src/app/(with-navigation)/project/page.tsx
+++ b/src/app/(with-navigation)/project/page.tsx
@@ -2,14 +2,14 @@
 
 import { useEffect, useState } from 'react';
 
-import { getProject, getProjectList, Project } from '@/apis/projects/get';
+import { getProjectList, ProjectList } from '@/apis/projects/get';
 
 import AddButton from './_components/add-button/AddButton';
 import NoItem from './_components/project-item/NoItem';
 import ProjectItem from './_components/project-item/ProjectItem';
 
 export default function ProjectPage() {
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<ProjectList['projects']>([]);
 
   useEffect(() => {
     getProjects();
@@ -19,8 +19,7 @@ export default function ProjectPage() {
     const { projects } = await getProjectList();
     setProjects(projects);
 
-    const data = await getProject();
-    console.log(data);
+    console.log(projects);
   };
 
   return (

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -40,6 +40,7 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
       startDate: dateRange.start,
       endDate: dateRange.end,
       goal,
+      content: description,
     };
     try {
       await addProject(body);

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { addProject } from '@/apis/projects/post';
 import DateRangeInput from '@/components/inputs/date/DateRangeInput';
 import Input from '@/components/inputs/input/Input';
 import LineInput from '@/components/inputs/line/LineInput';
@@ -19,18 +20,59 @@ interface Props {
 const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
   const { addToast } = useToast();
 
+  const [title, setTitle] = useState('');
   const [dateRange, setDateRange] = useState({ start: '', end: '' });
   const [goal, setGoal] = useState('');
   const [description, setDescription] = useState('');
 
   const [showExitAlert, setShowExitAlert] = useState(false);
 
+  const clearAllInputs = () => {
+    setTitle('');
+    setDateRange({ start: '', end: '' });
+    setGoal('');
+    setDescription('');
+  };
+
+  const enrollProject = async () => {
+    const body = {
+      title,
+      startDate: dateRange.start,
+      endDate: dateRange.end,
+      goal,
+    };
+    try {
+      await addProject(body);
+      addToast({
+        message: '프로젝트 내용이 저장되었어요.',
+        iconType: 'success',
+      });
+      closeSheet();
+      clearAllInputs();
+    } catch (error) {
+      addToast({
+        message: '프로젝트를 저장하는데 실패했어요.',
+        iconType: 'error',
+      });
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
   return (
     <>
       <RightActionSheetContainer
         isOpen={isOpen}
         closeActionSheet={() => {
-          if (dateRange.start || goal || description) {
+          if (
+            title ||
+            dateRange.start ||
+            dateRange.end ||
+            goal ||
+            description
+          ) {
             setShowExitAlert(true);
           } else {
             closeSheet();
@@ -39,19 +81,18 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
         buttons={[
           {
             text: '저장',
-            onClick: () => {
-              closeSheet();
-              addToast({
-                message: '프로젝트 내용이 저장되었어요.',
-                iconType: 'success',
-              });
-            },
+            onClick: enrollProject,
             buttonStyle: 'primary',
           },
         ]}
       >
         <div className="mb-5">
-          <LineInput placeholder="프로젝트 이름" className="!font-bold" />
+          <LineInput
+            placeholder="프로젝트 이름"
+            className="!font-bold"
+            value={title}
+            onChange={(e) => setTitle(e.currentTarget.value)}
+          />
         </div>
 
         <div className="flex flex-col gap-4">
@@ -91,7 +132,10 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
           },
           right: {
             text: '확인',
-            onClick: closeSheet,
+            onClick: () => {
+              closeSheet();
+              clearAllInputs();
+            },
           },
         }}
       />

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -66,10 +66,6 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
     }
   };
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
     <>
       <RightActionSheetContainer

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -58,6 +58,14 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
     }
   };
 
+  const onCloseSheet = () => {
+    if (title || dateRange.start || dateRange.end || goal || description) {
+      setShowExitAlert(true);
+    } else {
+      closeSheet();
+    }
+  };
+
   if (!isOpen) {
     return null;
   }
@@ -66,19 +74,7 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
     <>
       <RightActionSheetContainer
         isOpen={isOpen}
-        closeActionSheet={() => {
-          if (
-            title ||
-            dateRange.start ||
-            dateRange.end ||
-            goal ||
-            description
-          ) {
-            setShowExitAlert(true);
-          } else {
-            closeSheet();
-          }
-        }}
+        closeActionSheet={onCloseSheet}
         buttons={[
           {
             text: '저장',

--- a/src/components/action-sheets/edit-project/EditProjectSheet.tsx
+++ b/src/components/action-sheets/edit-project/EditProjectSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { editProject } from '@/apis/projects/put';
 import DateRangeInput from '@/components/inputs/date/DateRangeInput';
 import Input from '@/components/inputs/input/Input';
 import LineInput from '@/components/inputs/line/LineInput';
@@ -11,6 +12,7 @@ import useToast from '@/hooks/useToast';
 
 import RightActionSheetContainer from '../Container';
 import RelatedReview from '../project-detail/_components/RelatedReview';
+import { Review } from '../project-detail/ProjectDetailSheet';
 
 interface Props {
   isOpen: boolean;
@@ -20,6 +22,7 @@ interface Props {
   initialDate?: { start: string; end: string };
   initialGoal?: string;
   initialDescription?: string;
+  reviews?: Review[];
 }
 
 const EditProjectSheet = ({
@@ -30,6 +33,7 @@ const EditProjectSheet = ({
   initialDate,
   initialGoal,
   initialDescription,
+  reviews,
 }: Props) => {
   const { addToast } = useToast();
 
@@ -42,6 +46,30 @@ const EditProjectSheet = ({
 
   const [showDismissAlert, setShowDismissAlert] = useState(false);
 
+  const onClickSave = async () => {
+    const body = {
+      title,
+      startDate: dateRange.start,
+      endDate: dateRange.end,
+      goal,
+      content: description,
+    };
+
+    try {
+      await editProject(projectId, body);
+      addToast({
+        message: '프로젝트 내용이 수정되었어요.',
+        iconType: 'success',
+      });
+      closeSheet();
+    } catch (error) {
+      addToast({
+        message: '프로젝트 수정에 실패했어요. 다시 시도해주세요.',
+        iconType: 'error',
+      });
+    }
+  };
+
   return (
     <RightActionSheetContainer
       isOpen={isOpen}
@@ -49,13 +77,7 @@ const EditProjectSheet = ({
       buttons={[
         {
           text: '저장',
-          onClick: () => {
-            closeSheet();
-            addToast({
-              message: '프로젝트 내용이 수정되었어요.',
-              iconType: 'success',
-            });
-          },
+          onClick: onClickSave,
         },
       ]}
     >
@@ -97,24 +119,15 @@ const EditProjectSheet = ({
         <p className="mb-5 font-title-16 text-text-strong">연관된 회고</p>
 
         <div className="flex flex-col gap-3">
-          <RelatedReview
-            type="highlight"
-            review="시즌 프로모션 반응이 지난번이벤트보다 2배나 좋았음시즌
-                프로모션 반응이 지난번이벤트보다 2배나 좋았음시즌 프로모션
-                반응이 지난번이벤트보다 2배나 좋았음"
-            week="6월 1주차"
-          />
-          <RelatedReview
-            type="lowlight"
-            review="QA를 1달가까이 하는중이라 지쳐가는중"
-            week="5월 4주차"
-          />
-          <RelatedReview
-            type="lowlight"
-            review="QA를 1달가까이 하는중이라 지쳐가는중"
-            week="5월 3주차"
-            last
-          />
+          {reviews?.map((review) => (
+            <RelatedReview
+              key={review.id}
+              type={review.type}
+              review={review.content}
+              week={review.weekNumber}
+              last={review === reviews[reviews.length - 1]}
+            />
+          ))}
         </div>
       </div>
 

--- a/src/components/action-sheets/edit-project/EditProjectSheet.tsx
+++ b/src/components/action-sheets/edit-project/EditProjectSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { editProject } from '@/apis/projects/put';
 import DateRangeInput from '@/components/inputs/date/DateRangeInput';
@@ -37,14 +37,24 @@ const EditProjectSheet = ({
 }: Props) => {
   const { addToast } = useToast();
 
-  const [title, setTitle] = useState(initialTitle ?? '');
-  const [dateRange, setDateRange] = useState(
-    initialDate ?? { start: '', end: '' },
-  );
-  const [goal, setGoal] = useState(initialGoal ?? '');
-  const [description, setDescription] = useState(initialDescription ?? '');
+  const [title, setTitle] = useState('');
+  const [dateRange, setDateRange] = useState({ start: '', end: '' });
+  const [goal, setGoal] = useState('');
+  const [description, setDescription] = useState('');
 
   const [showDismissAlert, setShowDismissAlert] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setTitle(initialTitle ?? '');
+    setDateRange(initialDate ?? { start: '', end: '' });
+    setGoal(initialGoal ?? '');
+    setDescription(initialDescription ?? '');
+    setGoal(initialGoal ?? '');
+  }, [isOpen, initialTitle, initialDate, initialGoal, initialDescription]);
 
   const onClickSave = async () => {
     const body = {
@@ -69,6 +79,10 @@ const EditProjectSheet = ({
       });
     }
   };
+
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <RightActionSheetContainer

--- a/src/components/action-sheets/edit-project/EditProjectSheet.tsx
+++ b/src/components/action-sheets/edit-project/EditProjectSheet.tsx
@@ -80,10 +80,6 @@ const EditProjectSheet = ({
     }
   };
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
     <RightActionSheetContainer
       isOpen={isOpen}

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -107,8 +107,8 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
               </p>
 
               <ProjectProgress
-                startDate="2024.6.1"
-                endDate="2024.10.31"
+                startDate={projectInfo.startDate}
+                endDate={projectInfo.endDate}
                 percentage={projectInfo.progress}
               />
 
@@ -163,6 +163,14 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
         isOpen={openEditSheet}
         closeSheet={() => setOpenEditSheet(false)}
         projectId={projectId}
+        initialTitle={projectInfo?.title}
+        initialDate={{
+          start: projectInfo?.startDate ?? '',
+          end: projectInfo?.endDate ?? '',
+        }}
+        initialGoal={projectInfo?.goal}
+        initialDescription={projectInfo?.content}
+        reviews={reviews}
       />
     </>
   );

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -2,16 +2,15 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { getProject, Project } from '@/apis/projects/get';
+import { getProject, ProjectResponse } from '@/apis/projects/get';
 import Alert from '@/components/modal/Alert';
+import { Highlight } from '@/types/highlight';
 
 import RightActionSheetContainer from '../Container';
 import EditProjectSheet from '../edit-project/EditProjectSheet';
 import ProjectDetailItems from './_components/ProjectDetailItems';
 import ProjectProgress from './_components/ProjectProgress';
 import RelatedReview from './_components/RelatedReview';
-
-type Highlight = Project['highlights'][0];
 
 export interface Review extends Highlight {
   type: 'highlight' | 'lowlight';
@@ -26,7 +25,7 @@ interface Props {
 const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);
   const [openEditSheet, setOpenEditSheet] = useState(false);
-  const [projectInfo, setProjectInfo] = useState<Project>();
+  const [projectInfo, setProjectInfo] = useState<ProjectResponse>();
   const [reviews, setReviews] = useState<Review[]>([]);
 
   const getProjectInfo = useCallback(async () => {

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -11,22 +11,23 @@ import ProjectDetailItems from './_components/ProjectDetailItems';
 import ProjectProgress from './_components/ProjectProgress';
 import RelatedReview from './_components/RelatedReview';
 
+type Highlight = Project['highlights'][0];
+
+export interface Review extends Highlight {
+  type: 'highlight' | 'lowlight';
+}
+
 interface Props {
   isOpen: boolean;
   closeSheet: () => void;
   projectId: number;
 }
 
-type Highlight = Project['highlights'][0];
-interface ProjectItem extends Highlight {
-  type: 'highlight' | 'lowlight';
-}
-
 const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);
   const [openEditSheet, setOpenEditSheet] = useState(false);
   const [projectInfo, setProjectInfo] = useState<Project>();
-  const [reviews, setReviews] = useState<ProjectItem[]>([]);
+  const [reviews, setReviews] = useState<Review[]>([]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -73,7 +74,7 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
       }
     });
 
-    return reviews as ProjectItem[];
+    return reviews as Review[];
   };
 
   if (!isOpen) {

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { getProject, ProjectResponse } from '@/apis/projects/get';
 import Alert from '@/components/modal/Alert';
 import { Highlight } from '@/types/highlight';
+import { sortByWeek } from '@/types/sort';
 
 import RightActionSheetContainer from '../Container';
 import EditProjectSheet from '../edit-project/EditProjectSheet';
@@ -48,37 +49,15 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
     highlights: Highlight[],
     lowlights: Highlight[],
   ) => {
-    const highlight = highlights.map((highlight) => {
-      return {
-        ...highlight,
-        type: 'highlight',
-      };
-    });
-    const lowlight = lowlights.map((lowlight) => {
-      return {
-        ...lowlight,
-        type: 'lowlight',
-      };
-    });
+    const reviews = [
+      ...highlights.map((highlight) => ({ ...highlight, type: 'highlight' })),
+      ...lowlights.map((lowlight) => ({ ...lowlight, type: 'lowlight' })),
+    ];
 
-    const reviews = [...highlight, ...lowlight];
-    reviews.sort((a, b) => {
-      if (a.weekNumber.year === b.weekNumber.year) {
-        if (a.weekNumber.month === b.weekNumber.month) {
-          return b.weekNumber.week - a.weekNumber.week;
-        }
-        return b.weekNumber.month - a.weekNumber.month;
-      } else {
-        return b.weekNumber.year - a.weekNumber.year;
-      }
-    });
+    reviews.sort(sortByWeek);
 
     return reviews as Review[];
   };
-
-  if (!isOpen) {
-    return null;
-  }
 
   return (
     <>
@@ -127,7 +106,7 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
                 <div className="flex flex-col gap-3">
                   {reviews.map((review) => (
                     <RelatedReview
-                      key={review.id}
+                      key={`${review.type}-${review.id}`}
                       type={review.type}
                       review={review.content}
                       week={review.weekNumber}

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -30,7 +30,7 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
   const [reviews, setReviews] = useState<Review[]>([]);
 
   const getProjectInfo = useCallback(async () => {
-    const data = await getProject({ id: projectId });
+    const data = await getProject(projectId);
     setProjectInfo(data);
 
     const reviews = sortHighlightsAndLowlights(data.highlights, data.lowlights);

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { getProject, Project } from '@/apis/projects/get';
 import Alert from '@/components/modal/Alert';
@@ -29,21 +29,21 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
   const [projectInfo, setProjectInfo] = useState<Project>();
   const [reviews, setReviews] = useState<Review[]>([]);
 
+  const getProjectInfo = useCallback(async () => {
+    const data = await getProject({ id: projectId });
+    setProjectInfo(data);
+
+    const reviews = sortHighlightsAndLowlights(data.highlights, data.lowlights);
+    setReviews(reviews);
+  }, [projectId]);
+
   useEffect(() => {
     if (!isOpen) {
       return;
     }
 
     getProjectInfo();
-  }, [isOpen]);
-
-  const getProjectInfo = async () => {
-    const data = await getProject({ id: projectId });
-    setProjectInfo(data);
-
-    const reviews = sortHighlightsAndLowlights(data.highlights, data.lowlights);
-    setReviews(reviews);
-  };
+  }, [isOpen, getProjectInfo]);
 
   const sortHighlightsAndLowlights = (
     highlights: Highlight[],
@@ -161,7 +161,10 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
 
       <EditProjectSheet
         isOpen={openEditSheet}
-        closeSheet={() => setOpenEditSheet(false)}
+        closeSheet={async () => {
+          setOpenEditSheet(false);
+          await getProjectInfo();
+        }}
         projectId={projectId}
         initialTitle={projectInfo?.title}
         initialDate={{

--- a/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
+++ b/src/components/action-sheets/project-detail/ProjectDetailSheet.tsx
@@ -23,16 +23,22 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
   const [projectInfo, setProjectInfo] = useState<Project>();
 
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     getProjectInfo();
-  }, []);
+  }, [isOpen]);
 
   const getProjectInfo = async () => {
     const data = await getProject({ id: projectId });
+    console.log('data', data);
+
     setProjectInfo(data);
   };
 
-  if (!projectInfo) {
-    return <>loading...</>;
+  if (!isOpen) {
+    return null;
   }
 
   return (
@@ -53,68 +59,71 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
           },
         ]}
       >
-        <p className="font-head-24 text-text-strong mb-4">
-          {projectInfo.title}
-        </p>
+        <>
+          {projectInfo ? (
+            <>
+              <p className="font-head-24 text-text-strong mb-4">
+                {projectInfo.title}
+              </p>
+              <ProjectProgress
+                startDate="2024.6.1"
+                endDate="2024.10.31"
+                percentage={projectInfo.progress}
+              />
+              <div className="flex flex-col gap-4 mb-6">
+                <ProjectDetailItems title="목표" content={projectInfo.goal} />
+                <ProjectDetailItems
+                  title="내용"
+                  content={projectInfo.content}
+                />
+              </div>
+              <div>
+                <p className="mb-5 font-title-16 text-text-strong">
+                  연관된 회고
+                </p>
 
-        <ProjectProgress
-          startDate="2024.6.1"
-          endDate="2024.10.31"
-          percentage={projectInfo.progress}
-        />
-
-        <div className="flex flex-col gap-4 mb-6">
-          <ProjectDetailItems title="목표" content={projectInfo.goal} />
-          <ProjectDetailItems
-            title="내용"
-            content="현재 위치와 선택한 시간대에 맞는 실시간 차량 가용성 정보를
-              제공현재 위치와 선택한 시간대에 맞는 실시간 차량 가용성 정보를
-              제공현재 위치와 선택한 시간대에 맞는 실시간 차량 가용성 정보를
-              제공현재 위치와 선택한 시간대에 맞는 실시간 차량 가용성 정보를
-              제공"
-          />
-        </div>
-
-        <div>
-          <p className="mb-5 font-title-16 text-text-strong">연관된 회고</p>
-
-          <div className="flex flex-col gap-3">
-            <RelatedReview
-              type="highlight"
-              review="시즌 프로모션 반응이 지난번이벤트보다 2배나 좋았음시즌
+                <div className="flex flex-col gap-3">
+                  <RelatedReview
+                    type="highlight"
+                    review="시즌 프로모션 반응이 지난번이벤트보다 2배나 좋았음시즌
             프로모션 반응이 지난번이벤트보다 2배나 좋았음시즌 프로모션
             반응이 지난번이벤트보다 2배나 좋았음시즌 프로모션 반응이 지난번이벤트보다 2배나 좋았음"
-              week="6월 1주차"
-            />
-            <RelatedReview
-              type="lowlight"
-              review="QA를 1달가까이 하는중이라 지쳐가는중"
-              week="5월 4주차"
-            />
-            <RelatedReview
-              type="lowlight"
-              review="QA를 1달가까이 하는중이라 지쳐가는중"
-              week="5월 3주차"
-              last
-            />
-          </div>
-        </div>
-
-        <Alert
-          isOpen={showDeleteAlert}
-          title="정말로 삭제하시겠어요?"
-          onDismiss={() => setShowDeleteAlert(false)}
-          buttons={{
-            left: {
-              text: '취소',
-            },
-            right: {
-              text: '확인',
-              onClick: closeSheet,
-            },
-          }}
-        />
+                    week="6월 1주차"
+                  />
+                  <RelatedReview
+                    type="lowlight"
+                    review="QA를 1달가까이 하는중이라 지쳐가는중"
+                    week="5월 4주차"
+                  />
+                  <RelatedReview
+                    type="lowlight"
+                    review="QA를 1달가까이 하는중이라 지쳐가는중"
+                    week="5월 3주차"
+                    last
+                  />
+                </div>
+              </div>
+            </>
+          ) : (
+            <SheetLoading />
+          )}
+        </>
       </RightActionSheetContainer>
+
+      <Alert
+        isOpen={showDeleteAlert}
+        title="정말로 삭제하시겠어요?"
+        onDismiss={() => setShowDeleteAlert(false)}
+        buttons={{
+          left: {
+            text: '취소',
+          },
+          right: {
+            text: '확인',
+            onClick: closeSheet,
+          },
+        }}
+      />
 
       <EditProjectSheet
         isOpen={openEditSheet}
@@ -126,3 +135,11 @@ const ProjectDetailSheet = ({ isOpen, closeSheet, projectId }: Props) => {
 };
 
 export default ProjectDetailSheet;
+
+const SheetLoading = () => {
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <p className="font-body-16 text-text-weak">로딩중...</p>
+    </div>
+  );
+};

--- a/src/components/action-sheets/project-detail/_components/RelatedReview.tsx
+++ b/src/components/action-sheets/project-detail/_components/RelatedReview.tsx
@@ -1,13 +1,14 @@
 import ChevronRight16Icon from '@/components/icons/ChevronRight16Icon';
 import HighlightCircleIcon from '@/components/icons/HighlightCircleIcon';
 import LowlightCircleIcon from '@/components/icons/LowlightCircleIcon';
+import { CurrentWeek } from '@/types/currentWeek';
 
 import Connector from './Connector';
 
 interface Props {
   type: 'highlight' | 'lowlight';
   review: string;
-  week: string;
+  week: CurrentWeek;
   last?: boolean;
 }
 
@@ -28,7 +29,7 @@ const RelatedReview = ({ type, review, week, last }: Props) => {
         </div>
 
         <div className="flex items-center gap-0.5 justify-end">
-          <p className="font-body-13 text-text-strong">{week}</p>
+          <p className="font-body-13 text-text-strong">{`${week.month}월 ${week.week}주차`}</p>
           <ChevronRight16Icon size={16} />
         </div>
       </div>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,9 +4,12 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import TextLogo from '@/components/icons/TextLogo';
+import { getCurrentWeek } from '@/utils/date';
 
 import SettingProfileModal from '../modal/setting-profile';
 import WeekInfo from './WeekInfo';
+
+const { totalWeek, week } = getCurrentWeek();
 
 const Header = () => {
   const [openSettingModal, setOpenSettingModal] = useState(false);
@@ -18,7 +21,7 @@ const Header = () => {
           <TextLogo />
         </Link>
 
-        <WeekInfo totalWeek={4} currentWeek={1} />
+        <WeekInfo totalWeek={totalWeek} currentWeek={week} />
 
         <button
           className="w-10 h-10 bg-surface-alternative rounded-[14px] flex items-center justify-center text-text-invert select-none"

--- a/src/types/highlight.ts
+++ b/src/types/highlight.ts
@@ -1,0 +1,7 @@
+import { CurrentWeek } from './currentWeek';
+
+export interface Highlight {
+  id: number;
+  content: string;
+  weekNumber: CurrentWeek;
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,7 @@
+export interface Project {
+  title: string;
+  goal: string;
+  content: string;
+  startDate: string;
+  endDate: string;
+}

--- a/src/types/sort.ts
+++ b/src/types/sort.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const sortByWeek = (a: any, b: any) => {
+  const compareYear = b.weekNumber.year - a.weekNumber.year;
+  const compareMonth = b.weekNumber.month - a.weekNumber.month;
+  const compareWeek = b.weekNumber.week - a.weekNumber.week;
+
+  return compareYear || compareMonth || compareWeek;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -8,5 +8,9 @@ export const getCurrentWeek = () => {
   const firstDay = new Date(now.setDate(1)).getDay();
   const week = Math.ceil((day + firstDay) / 7);
 
-  return { year, month, week };
+  const totalWeek = Math.ceil(
+    (new Date(year, month, 0).getDate() + firstDay) / 7,
+  );
+
+  return { year, month, week, totalWeek };
 };


### PR DESCRIPTION
프로젝트 페이지 api 연동했습니다.

- 프로젝트 생성은 현재 두 가지 이슈가 있어서 백엔드에 문의 남겨놨습니다!
  - 프로젝트를 생성해도 목록 조회를 했을 때 보이지 않는 이슈
  - 프로젝트 생성 시 `내용` 항목을 서버에서 받고 있지 않음

- 프로젝트의 `연관된 회고` 항목은 현재 백엔드에서 하이라이트, 로우라이트 목록을 보내주고 있어서 아래와 같이 노출하고 있습니다.
  - 먼저 두 항목을 합친다음
  - 최신순으로 정렬해서

- 삭제 api가 없어서. 연동 예외 케이스 페이지에 요청 남겨놨습니다

- 헤더에 하드코딩 되어 있던 현재 주차 정보를 실 데이터로 변경했습니다.
![image](https://github.com/user-attachments/assets/18b16fa5-50f6-4d0c-9ae1-4bfeb7f68a67)
