### PR TITLE
[FIX] 히스토리 페이지 수정

### DIFF
--- a/src/apis/memo/get.ts
+++ b/src/apis/memo/get.ts
@@ -18,7 +18,10 @@ export const getMemos = async ({ year, month, week }: CurrentWeek) => {
 export interface AllMemosResponse {
   contents: {
     weekNumber: CurrentWeek;
-    memos: Memo[];
+    id: number;
+    content: string;
+    isMarked: boolean;
+    updatedAt: string;
   }[];
   nextCursor: number;
 }

--- a/src/apis/reports/get.ts
+++ b/src/apis/reports/get.ts
@@ -17,7 +17,7 @@ interface ReviewListResponse {
 }
 
 export const getReviewList = async () => {
-  const response = await typedGet<ReviewListResponse>('/review');
+  const response = await typedGet<ReviewListResponse>('/reviews/page');
   return response;
 };
 

--- a/src/app/(with-navigation)/history/_components/Category.tsx
+++ b/src/app/(with-navigation)/history/_components/Category.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useAtom } from 'jotai';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import PlusIcon from '@/components/icons/PlusIcon';
 import ToggleSwitch from '@/components/toggle-switch/ToggleSwitch';
+import { showOnlyBookmarkAtom } from '@/stores/bookmark/showOnlyBookmarkAtom';
 import { cn } from '@/utils/tailwind';
 
 import { dummy } from '../memo/_components/MemoHistory/dummy';
@@ -22,6 +24,8 @@ const menus = [
 
 const Category = () => {
   const currentPathname = usePathname();
+
+  const [showBookmarkOnly, setShowBookmarkOnly] = useAtom(showOnlyBookmarkAtom);
 
   return (
     <div className="flex items-center justify-between mb-5">
@@ -44,7 +48,10 @@ const Category = () => {
         {currentPathname === '/history/memo' && dummy.length > 0 && (
           <div className="flex items-center gap-1">
             <p className="font-body-14 text-text-normal">북마크만 보기</p>
-            <ToggleSwitch />
+            <ToggleSwitch
+              initialState={showBookmarkOnly}
+              onChange={setShowBookmarkOnly}
+            />
           </div>
         )}
       </div>

--- a/src/app/(with-navigation)/history/memo/_components/MemoHistory/MemoHistory.tsx
+++ b/src/app/(with-navigation)/history/memo/_components/MemoHistory/MemoHistory.tsx
@@ -3,30 +3,76 @@
 import { useEffect, useState } from 'react';
 
 import { AllMemosResponse, getAllMemos } from '@/apis/memo/get';
+import { Memo } from '@/types/memo';
+import { sortByWeek } from '@/types/sort';
 
 import EmptyMemoHistory from './EmptyMemoHistory';
+import MemoWeekGroup from './MemoWeekGroup';
 
 const MemoHistory = () => {
-  const [memos, setMemos] = useState<AllMemosResponse>();
+  const [memos, setMemos] = useState<
+    {
+      weekNumber: { year: number; month: number; week: number };
+      memos: Memo[];
+    }[]
+  >([]);
+
+  const groupMemosByWeek = (receivedMemos: AllMemosResponse) => {
+    const groupedMemos = receivedMemos.contents.reduce(
+      (acc, cur) => {
+        const { year, month, week } = cur.weekNumber;
+
+        const item = {
+          id: cur.id,
+          content: cur.content,
+          isMarked: cur.isMarked,
+          updatedAt: cur.updatedAt,
+        };
+
+        const key = `${year}-${month}-${week}`;
+        if (acc[key]) {
+          acc[key].memos.push(item);
+        } else {
+          acc[key] = {
+            weekNumber: cur.weekNumber,
+            memos: [item],
+          };
+        }
+
+        return acc;
+      },
+      {} as Record<
+        string,
+        {
+          weekNumber: { year: number; month: number; week: number };
+          memos: Memo[];
+        }
+      >,
+    );
+
+    return Object.values(groupedMemos).sort(sortByWeek);
+  };
 
   useEffect(() => {
     (async () => {
       const response = await getAllMemos({});
-      setMemos(response);
+
+      const sorted = groupMemosByWeek(response);
+      setMemos(sorted);
     })();
   }, []);
 
-  if (!memos || memos.contents.length === 0) return <EmptyMemoHistory />;
+  if (memos.length === 0) return <EmptyMemoHistory />;
 
   return (
     <>
-      {/* {memos.contents.map(({ weekNumber, memos }) => (
+      {memos.map(({ weekNumber, memos }) => (
         <MemoWeekGroup
           key={`${weekNumber.year}-${weekNumber.month}-${weekNumber.week}`}
           currentWeek={weekNumber}
           memos={memos}
         />
-      ))} */}
+      ))}
       <p>memo</p>
     </>
   );

--- a/src/app/(with-navigation)/history/memo/_components/MemoHistory/MemoWeekGroup.tsx
+++ b/src/app/(with-navigation)/history/memo/_components/MemoHistory/MemoWeekGroup.tsx
@@ -22,7 +22,7 @@ const MemoWeekGroup = ({ currentWeek, memos }: Props) => {
           <Memo
             key={item.id}
             id={String(item.id)}
-            title={item.content}
+            memo={item.content}
             date="7.22"
             isBookmark={item.isMarked}
             className="w-[229px] h-[10rem]"

--- a/src/app/(with-navigation)/history/review/_components/ReviewDetailSheet/ReviewDetail.tsx
+++ b/src/app/(with-navigation)/history/review/_components/ReviewDetailSheet/ReviewDetail.tsx
@@ -90,7 +90,7 @@ export const ReviewDetail = ({ weekNumber }: Props) => {
 
       <div className="flex flex-col gap-4">
         <p className="font-title-14 text-text-strong">완료한 일</p>
-        <div className="pl-8">
+        <div className="pl-8 flex flex-col gap-2">
           {completedTodos.map((todo) => (
             <DeletableInput key={`todo-${todo.id}`} value={todo.content} />
           ))}

--- a/src/app/(with-navigation)/history/review/_components/ReviewDetailSheet/ReviewDetail.tsx
+++ b/src/app/(with-navigation)/history/review/_components/ReviewDetailSheet/ReviewDetail.tsx
@@ -57,7 +57,7 @@ export const ReviewDetail = ({ weekNumber }: Props) => {
           <HighlightCircleIcon size={24} />
           <p className="font-title-14 text-text-strong">하이라이트</p>
         </div>
-        <div className="pl-8">
+        <div className="pl-8 flex flex-col gap-2">
           {highlights.map((highlight) => (
             <LastWeekReviewItem
               key={`highlight-${highlight.id}`}
@@ -75,7 +75,7 @@ export const ReviewDetail = ({ weekNumber }: Props) => {
           <LowlightCircleIcon size={24} />
           <p className="font-title-14 text-text-strong">로우라이트</p>
         </div>
-        <div className="pl-8">
+        <div className="pl-8 flex flex-col gap-2">
           {lowlights.map((lowlight) => (
             <LastWeekReviewItem
               key={`lowlight-${lowlight.id}`}

--- a/src/components/toggle-switch/ToggleSwitch.tsx
+++ b/src/components/toggle-switch/ToggleSwitch.tsx
@@ -18,9 +18,7 @@ const ToggleSwitch = ({
   const toggle = () => {
     setIsOn((prev) => !prev);
 
-    if (onChange) {
-      onChange(isOn);
-    }
+    onChange?.(!isOn);
   };
 
   return (

--- a/src/stores/bookmark/showOnlyBookmarkAtom.ts
+++ b/src/stores/bookmark/showOnlyBookmarkAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const showOnlyBookmarkAtom = atom(false);


### PR DESCRIPTION
기존에 weekNumber 정보를 기준으로 묶어서 오던 메모 리스트가 타입이 바뀌면서 프론트에서 다시 weekNumber를 기준으로 묶어서 렌더링하도록 변경했습니다.

추가로 히스토리 > 메모 탭에 있는 `북마크만 보기` 기능도 개발했습니다.