### PR TITLE
[FEAT] 주차 이동 구현 

### DIFF
--- a/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
@@ -39,11 +39,7 @@ const MemoList = () => {
   };
 
   useEffect(() => {
-    getMemoList({
-      year: currentWeek.year,
-      month: currentWeek.month,
-      week: currentWeek.week,
-    });
+    getMemoList(currentWeek);
   }, [currentWeek]);
 
   const addMemo = async (content: string) => {

--- a/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
@@ -12,6 +12,7 @@ import PlusIcon from '@/components/icons/PlusIcon';
 import Memo from '@/components/memo/Memo';
 import TextEditorModal from '@/components/modal/text-editor';
 import { displayWeekAtom } from '@/stores/week/displayWeek';
+import { CurrentWeek } from '@/types/currentWeek';
 import { getMemoCreateDate } from '@/utils/date';
 
 const MemoList = () => {
@@ -19,11 +20,11 @@ const MemoList = () => {
   const [memos, setMemos] = useAtom(memoListAtom);
   const currentWeek = useAtomValue(displayWeekAtom);
 
-  const getMemoList = async () => {
+  const getMemoList = async ({ year, month, week }: CurrentWeek) => {
     const data = await getMemos({
-      year: currentWeek.year,
-      month: currentWeek.month,
-      week: currentWeek.week,
+      year,
+      month,
+      week,
     });
     setMemos(
       data.memos.map((memo) => {
@@ -38,8 +39,12 @@ const MemoList = () => {
   };
 
   useEffect(() => {
-    getMemoList();
-  }, []);
+    getMemoList({
+      year: currentWeek.year,
+      month: currentWeek.month,
+      week: currentWeek.week,
+    });
+  }, [currentWeek]);
 
   const addMemo = async (content: string) => {
     try {

--- a/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
@@ -11,16 +11,20 @@ import EmptyMemoImage from '@/assets/images/memo-empty.png';
 import PlusIcon from '@/components/icons/PlusIcon';
 import Memo from '@/components/memo/Memo';
 import TextEditorModal from '@/components/modal/text-editor';
-import { getCurrentWeek, getMemoCreateDate } from '@/utils/date';
-
-const { year, month, week } = getCurrentWeek();
+import { displayWeekAtom } from '@/stores/week/displayWeek';
+import { getMemoCreateDate } from '@/utils/date';
 
 const MemoList = () => {
   const [openTextEditor, setOpenTextEditor] = useState(false);
   const [memos, setMemos] = useAtom(memoListAtom);
+  const currentWeek = useAtomValue(displayWeekAtom);
 
   const getMemoList = async () => {
-    const data = await getMemos({ year, month, week: week - 1 });
+    const data = await getMemos({
+      year: currentWeek.year,
+      month: currentWeek.month,
+      week: currentWeek.week,
+    });
     setMemos(
       data.memos.map((memo) => {
         return {

--- a/src/app/(with-navigation)/dashboards/_components/TodoList.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/TodoList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAtomValue } from 'jotai';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
@@ -11,20 +12,20 @@ import EmptyTodoImage from '@/assets/images/todo-empty.png';
 import DeleteIcon from '@/components/icons/DeleteIcon';
 import PlusIcon from '@/components/icons/PlusIcon';
 import CheckboxInput from '@/components/inputs/checkbox/CheckboxInput';
+import { displayWeekAtom } from '@/stores/week/displayWeek';
+import { CurrentWeek } from '@/types/currentWeek';
 import { Todo } from '@/types/todo';
-import { getCurrentWeek } from '@/utils/date';
-
-const { year, month, week } = getCurrentWeek();
 
 const TodoList = () => {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [addNewTodo, setAddNewTodo] = useState(false);
+  const { year, month, week } = useAtomValue(displayWeekAtom);
 
   useEffect(() => {
-    getCurrentWeekTodos();
-  }, []);
+    getCurrentWeekTodos({ year, month, week });
+  }, [year, month, week]);
 
-  const getCurrentWeekTodos = async () => {
+  const getCurrentWeekTodos = async ({ year, month, week }: CurrentWeek) => {
     const response = await getTodos({ year, month, week });
     setTodos(response.todos);
   };
@@ -42,7 +43,7 @@ const TodoList = () => {
 
     try {
       await changeTodos(updatedTodos);
-      await getCurrentWeekTodos();
+      await getCurrentWeekTodos({ year, month, week });
     } catch (error) {
       console.error('fail to change checkbox', error);
     }
@@ -56,7 +57,7 @@ const TodoList = () => {
           .filter((todo) => todo.id < 1)
           .map((todo) => ({ content: todo.content })),
       });
-      await getCurrentWeekTodos();
+      await getCurrentWeekTodos({ year, month, week });
     } catch (error) {
       console.error('fail to add todos', error);
     }

--- a/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
@@ -58,8 +58,13 @@ const WeekNavigator = () => {
       </p>
       <div className="flex gap-1.5">
         <button
-          className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center"
+          className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center disabled:bg-surface-foregroundOn"
           onClick={handleClickPrev}
+          disabled={
+            currentDisplayWeek.year === 2024 &&
+            currentDisplayWeek.month === 1 &&
+            currentDisplayWeek.week === 1
+          }
         >
           <ChevronLeft20Icon size={20} />
         </button>

--- a/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
@@ -1,20 +1,62 @@
+import { Day, nextDay, previousDay } from 'date-fns';
+import { useAtom } from 'jotai';
+
 import ChevronLeft20Icon from '@/components/icons/ChevronLeft20Icon';
 import ChevronRight20Icon from '@/components/icons/ChevronRight20Icon';
+import { displayWeekAtom } from '@/stores/week/displayWeek';
 import { getCurrentWeek } from '@/utils/date';
 
-const { month, week } = getCurrentWeek();
-
 const WeekNavigator = () => {
+  const [currentWeek, setCurrentWeek] = useAtom(displayWeekAtom);
+
+  const handleClickPrev = () => {
+    const prevWeek = previousDay(
+      new Date(currentWeek.year, currentWeek.month - 1, currentWeek.date),
+      currentWeek.day,
+    );
+    const { year, month, week } = getCurrentWeek(prevWeek);
+
+    setCurrentWeek({
+      year,
+      month,
+      week,
+      date: prevWeek.getDate(),
+      day: prevWeek.getDay(),
+    });
+  };
+
+  const handleClickNext = () => {
+    const nextWeek = nextDay(
+      new Date(currentWeek.year, currentWeek.month - 1, currentWeek.date),
+      currentWeek.day as Day,
+    );
+    const { year, month, week } = getCurrentWeek(nextWeek);
+
+    setCurrentWeek({
+      year,
+      month,
+      week,
+      date: nextWeek.getDate(),
+      day: nextWeek.getDay(),
+    });
+  };
+
   return (
     <div className="flex items-center gap-2">
       <p className="font-head-20 text-text-strong">
-        {month}월 {week}주차
+        {currentWeek.month}월 {currentWeek.week}주차
       </p>
       <div className="flex gap-1.5">
-        <button className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center">
+        <button
+          className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center"
+          onClick={handleClickPrev}
+        >
           <ChevronLeft20Icon size={20} />
         </button>
-        <button className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center">
+        <button
+          className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center"
+          onClick={handleClickNext}
+        >
           <ChevronRight20Icon size={20} />
         </button>
       </div>

--- a/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
@@ -20,11 +20,14 @@ const WeekNavigator = () => {
       ),
       currentDisplayWeek.day,
     );
-    const { year, month, week } = getCurrentWeek(prevWeek);
+
+    console.log('prevWeek', prevWeek);
+
+    const { week } = getCurrentWeek(prevWeek);
 
     setCurrentDisplayWeek({
-      year,
-      month,
+      year: prevWeek.getFullYear(),
+      month: prevWeek.getMonth() + 1,
       week,
       date: prevWeek.getDate(),
       day: prevWeek.getDay(),
@@ -40,11 +43,11 @@ const WeekNavigator = () => {
       ),
       currentDisplayWeek.day as Day,
     );
-    const { year, month, week } = getCurrentWeek(nextWeek);
+    const { week } = getCurrentWeek(nextWeek);
 
     setCurrentDisplayWeek({
-      year,
-      month,
+      year: nextWeek.getFullYear(),
+      month: nextWeek.getMonth() + 1,
       week,
       date: nextWeek.getDate(),
       day: nextWeek.getDay(),

--- a/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/WeekNavigator.tsx
@@ -6,17 +6,23 @@ import ChevronRight20Icon from '@/components/icons/ChevronRight20Icon';
 import { displayWeekAtom } from '@/stores/week/displayWeek';
 import { getCurrentWeek } from '@/utils/date';
 
+const { year, month, week } = getCurrentWeek();
+
 const WeekNavigator = () => {
-  const [currentWeek, setCurrentWeek] = useAtom(displayWeekAtom);
+  const [currentDisplayWeek, setCurrentDisplayWeek] = useAtom(displayWeekAtom);
 
   const handleClickPrev = () => {
     const prevWeek = previousDay(
-      new Date(currentWeek.year, currentWeek.month - 1, currentWeek.date),
-      currentWeek.day,
+      new Date(
+        currentDisplayWeek.year,
+        currentDisplayWeek.month - 1,
+        currentDisplayWeek.date,
+      ),
+      currentDisplayWeek.day,
     );
     const { year, month, week } = getCurrentWeek(prevWeek);
 
-    setCurrentWeek({
+    setCurrentDisplayWeek({
       year,
       month,
       week,
@@ -27,12 +33,16 @@ const WeekNavigator = () => {
 
   const handleClickNext = () => {
     const nextWeek = nextDay(
-      new Date(currentWeek.year, currentWeek.month - 1, currentWeek.date),
-      currentWeek.day as Day,
+      new Date(
+        currentDisplayWeek.year,
+        currentDisplayWeek.month - 1,
+        currentDisplayWeek.date,
+      ),
+      currentDisplayWeek.day as Day,
     );
     const { year, month, week } = getCurrentWeek(nextWeek);
 
-    setCurrentWeek({
+    setCurrentDisplayWeek({
       year,
       month,
       week,
@@ -44,7 +54,7 @@ const WeekNavigator = () => {
   return (
     <div className="flex items-center gap-2">
       <p className="font-head-20 text-text-strong">
-        {currentWeek.month}월 {currentWeek.week}주차
+        {currentDisplayWeek.month}월 {currentDisplayWeek.week}주차
       </p>
       <div className="flex gap-1.5">
         <button
@@ -54,8 +64,13 @@ const WeekNavigator = () => {
           <ChevronLeft20Icon size={20} />
         </button>
         <button
-          className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center"
+          className="bg-surface-foreground w-7 h-7 rounded-md flex items-center justify-center disabled:bg-surface-foregroundOn"
           onClick={handleClickNext}
+          disabled={
+            currentDisplayWeek.year === year &&
+            currentDisplayWeek.month === month &&
+            currentDisplayWeek.week === week
+          }
         >
           <ChevronRight20Icon size={20} />
         </button>

--- a/src/app/(with-navigation)/dashboards/page.tsx
+++ b/src/app/(with-navigation)/dashboards/page.tsx
@@ -1,34 +1,38 @@
 'use client';
 
 import { AxiosError } from 'axios';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { DashboardDataResponse, getDashboardData } from '@/apis/dashboard/get';
 import { currentTodoListAtom } from '@/app/review/stores';
 import { useUser } from '@/hooks/useUser';
-import { getCurrentWeek } from '@/utils/date';
+import { displayWeekAtom } from '@/stores/week/displayWeek';
+import { CurrentWeek } from '@/types/currentWeek';
 
 import MemoList from './_components/MemoList';
 import Metrics from './_components/Metrics';
 import TodoList from './_components/TodoList';
 import WeekNavigator from './_components/WeekNavigator';
 
-const { year, month, week } = getCurrentWeek();
-
 export default function DashboardPage() {
   const setTodos = useSetAtom(currentTodoListAtom);
+  const currentWeek = useAtomValue(displayWeekAtom);
 
   const { userExpired } = useUser();
 
   const [data, setData] = useState<DashboardDataResponse>();
 
   useEffect(() => {
-    getData();
-  }, []);
+    getData({
+      year: currentWeek.year,
+      month: currentWeek.month,
+      week: currentWeek.week,
+    });
+  }, [currentWeek]);
 
-  const getData = async () => {
+  const getData = async ({ year, month, week }: CurrentWeek) => {
     try {
       const data = await getDashboardData({ year, month, week });
       setData(data);

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,12 +4,9 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import TextLogo from '@/components/icons/TextLogo';
-import { getCurrentWeek } from '@/utils/date';
 
 import SettingProfileModal from '../modal/setting-profile';
 import WeekInfo from './WeekInfo';
-
-const { totalWeek, week } = getCurrentWeek();
 
 const Header = () => {
   const [openSettingModal, setOpenSettingModal] = useState(false);
@@ -21,7 +18,7 @@ const Header = () => {
           <TextLogo />
         </Link>
 
-        <WeekInfo totalWeek={totalWeek} currentWeek={week} />
+        <WeekInfo />
 
         <button
           className="w-10 h-10 bg-surface-alternative rounded-[14px] flex items-center justify-center text-text-invert select-none"

--- a/src/components/header/WeekInfo.tsx
+++ b/src/components/header/WeekInfo.tsx
@@ -1,15 +1,31 @@
+import { useAtomValue } from 'jotai';
+import { useEffect, useState } from 'react';
+
+import { displayWeekAtom } from '@/stores/week/displayWeek';
+import { getCurrentWeek } from '@/utils/date';
 import { cn } from '@/utils/tailwind';
 
-interface Props {
-  totalWeek: number;
-  currentWeek: number;
-}
+const WeekInfo = () => {
+  const [totalWeek, setTotalWeek] = useState(5);
 
-const WeekInfo = ({ totalWeek, currentWeek }: Props) => {
+  const currentWeek = useAtomValue(displayWeekAtom);
+
+  useEffect(() => {
+    const weekInfo = getCurrentWeek(
+      new Date(currentWeek.year, currentWeek.month - 1, currentWeek.date),
+    );
+
+    setTotalWeek(weekInfo.totalWeek);
+  }, [currentWeek]);
+
   return (
     <div className="flex items-center gap-1">
       {Array.from({ length: totalWeek }, (_, i) => (
-        <WeekItem key={i} currentWeek={i + 1} active={currentWeek === i + 1} />
+        <WeekItem
+          key={i}
+          currentWeek={i + 1}
+          active={currentWeek.week === i + 1}
+        />
       ))}
     </div>
   );
@@ -17,7 +33,8 @@ const WeekInfo = ({ totalWeek, currentWeek }: Props) => {
 
 export default WeekInfo;
 
-interface WeekItemProps extends Pick<Props, 'currentWeek'> {
+interface WeekItemProps {
+  currentWeek: number;
   active?: boolean;
 }
 

--- a/src/stores/week/displayWeek.ts
+++ b/src/stores/week/displayWeek.ts
@@ -10,5 +10,5 @@ export const displayWeekAtom = atom({
   month,
   week,
   date: now.getDate(),
-  day: now.getDay(),
+  day: now.getDay() === 0 ? now.getDay() : 4,
 });

--- a/src/stores/week/displayWeek.ts
+++ b/src/stores/week/displayWeek.ts
@@ -1,0 +1,14 @@
+import { atom } from 'jotai';
+
+import { getCurrentWeek } from '@/utils/date';
+
+const { year, month, week } = getCurrentWeek();
+const now = new Date();
+
+export const displayWeekAtom = atom({
+  year,
+  month,
+  week,
+  date: now.getDate(),
+  day: now.getDay(),
+});


### PR DESCRIPTION
이전 주, 다음 주 이동하는 로직을 구현했습니다.

- 1월 1주차보다 이전으로는 이동할 수 없습니다.
- 현재 주차보다 미래로는 이동할 수 없습니다.
- 헤더에 있는 정보도 현재 주차에 맞추어 표시됩니다.