### PR TITLE
[FEAT] 유저 프로필 부분 구현

### DIFF
--- a/src/apis/user/get.ts
+++ b/src/apis/user/get.ts
@@ -1,8 +1,8 @@
 import { typedGet } from '..';
 
-interface UserDetail {
+export interface UserDetail {
   email: string;
-  nickname: string;
+  nickname?: string;
 }
 
 export const getUserDetail = async () => {

--- a/src/apis/user/get.ts
+++ b/src/apis/user/get.ts
@@ -1,0 +1,11 @@
+import { typedGet } from '..';
+
+interface UserDetail {
+  email: string;
+  nickname: string;
+}
+
+export const getUserDetail = async () => {
+  const response = await typedGet<UserDetail>('/auth/user');
+  return response;
+};

--- a/src/apis/user/put.ts
+++ b/src/apis/user/put.ts
@@ -1,0 +1,6 @@
+import { typedPut } from '..';
+
+export const changeNickname = async (nickname: string) => {
+  const response = typedPut('/auth/nickname', { nickname });
+  return response;
+};

--- a/src/app/(with-navigation)/dashboards/_components/TodoList.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/TodoList.tsx
@@ -114,7 +114,7 @@ const TodoList = () => {
             <CheckboxInput
               key={index}
               value={todo.content}
-              placeholder="이번 주의 나에게"
+              placeholder="할 일을 입력해 주세요"
               checked={todo.status === 'DONE'}
               onChange={(value) =>
                 setTodos((prev) =>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useAtom } from 'jotai';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { getUserDetail } from '@/apis/user/get';
@@ -12,6 +13,8 @@ import SettingProfileModal from '../modal/setting-profile';
 import WeekInfo from './WeekInfo';
 
 const Header = () => {
+  const router = useRouter();
+
   const [openSettingModal, setOpenSettingModal] = useState(false);
   const [userInfo, setUserInfo] = useAtom(userInfoAtom);
 
@@ -37,7 +40,11 @@ const Header = () => {
 
         <button
           className="w-10 h-10 bg-surface-alternative rounded-[14px] flex items-center justify-center text-text-invert select-none"
-          onClick={() => setOpenSettingModal(true)}
+          onClick={() =>
+            userInfo.email
+              ? setOpenSettingModal(true)
+              : router.push('/auth/login')
+          }
         >
           {userInfo.nickname ? userInfo.nickname[0] : userInfo.email[0]}
         </button>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,15 +1,30 @@
 'use client';
 
+import { useAtom } from 'jotai';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { getUserDetail } from '@/apis/user/get';
 import TextLogo from '@/components/icons/TextLogo';
+import { userInfoAtom } from '@/stores/user/userInfo';
 
 import SettingProfileModal from '../modal/setting-profile';
 import WeekInfo from './WeekInfo';
 
 const Header = () => {
   const [openSettingModal, setOpenSettingModal] = useState(false);
+  const [userInfo, setUserInfo] = useAtom(userInfoAtom);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await getUserDetail();
+        setUserInfo(response);
+      } catch (error) {
+        console.error('fail to get user profile', error);
+      }
+    })();
+  }, [setUserInfo]);
 
   return (
     <header className="h-[3.25rem] w-full min-w-[1440px] sticky top-0 left-0 right-0 bg-surface-invert flex items-center justify-center z-10">
@@ -24,7 +39,7 @@ const Header = () => {
           className="w-10 h-10 bg-surface-alternative rounded-[14px] flex items-center justify-center text-text-invert select-none"
           onClick={() => setOpenSettingModal(true)}
         >
-          이
+          {userInfo.nickname ? userInfo.nickname[0] : userInfo.email[0]}
         </button>
       </div>
 

--- a/src/components/modal/setting-profile/SettingAccount.tsx
+++ b/src/components/modal/setting-profile/SettingAccount.tsx
@@ -2,9 +2,13 @@
 
 import { useState } from 'react';
 
+import { useUser } from '@/hooks/useUser';
+
 import Alert from '../Alert';
 
 const SettingAccount = () => {
+  const { userLogout } = useUser();
+
   const [showConfirmAlert, setShowConfirmAlert] = useState(false);
 
   return (
@@ -22,7 +26,10 @@ const SettingAccount = () => {
           >
             회원탈퇴
           </button>
-          <button className="button-line button-medium text-text-strong flex-1">
+          <button
+            className="button-line button-medium text-text-strong flex-1"
+            onClick={userLogout}
+          >
             로그아웃
           </button>
         </div>

--- a/src/components/modal/setting-profile/SettingProfile.tsx
+++ b/src/components/modal/setting-profile/SettingProfile.tsx
@@ -1,30 +1,47 @@
 'use client';
 
+import { useAtom } from 'jotai';
 import { useState } from 'react';
 
+import { changeNickname } from '@/apis/user/put';
 import Input from '@/components/inputs/input/Input';
 import useToast from '@/hooks/useToast';
+import { userInfoAtom } from '@/stores/user/userInfo';
 
 const SettingProfile = () => {
   const { addToast } = useToast();
 
-  const [nickname, setNickname] = useState('');
+  const [userInfo, setUserInfo] = useAtom(userInfoAtom);
+  const [nickname, setNickname] = useState(userInfo.nickname ?? '');
+
+  const onClickChangeNickname = async () => {
+    try {
+      await changeNickname(nickname);
+      addToast({
+        message: '닉네임이 변경되었어요.',
+        iconType: 'success',
+      });
+      setUserInfo((prev) => ({ ...prev, nickname }));
+    } catch (error) {
+      console.error('fail to change nickname', error);
+      addToast({
+        message: '닉네임 변경에 실패했어요.',
+        iconType: 'error',
+      });
+    }
+  };
 
   return (
     <div className="flex flex-col gap-5 w-full">
       <div>
         <p className="font-body-14 text-text-strong mb-2">가입한 이메일</p>
-        <Input value="hkjkjklj@gmail.com" readOnly />
+        <Input value={userInfo.email} readOnly />
       </div>
 
       <form
-        onSubmit={(e) => {
+        onSubmit={async (e) => {
           e.preventDefault();
-
-          addToast({
-            message: '닉네임이 변경되었어요.',
-            iconType: 'success',
-          });
+          await onClickChangeNickname();
         }}
       >
         <label htmlFor="nickname" className="font-body-14 text-text-strong">

--- a/src/components/modal/setting-profile/index.tsx
+++ b/src/components/modal/setting-profile/index.tsx
@@ -7,18 +7,18 @@ import { ModalProps } from '../ModalContainer';
 import SettingAccount from './SettingAccount';
 import SettingProfile from './SettingProfile';
 
-const menus = [
-  {
-    label: '프로필',
-    component: <SettingProfile />,
-  },
-  {
-    label: '계정',
-    component: <SettingAccount />,
-  },
-];
-
 const SettingProfileModal = (props: ModalProps) => {
+  const menus = [
+    {
+      label: '프로필',
+      component: <SettingProfile />,
+    },
+    {
+      label: '계정',
+      component: <SettingAccount />,
+    },
+  ];
+
   const [currentMenu, setCurrentMenu] = useState(menus[0].label);
 
   return (

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -40,6 +40,12 @@ export const useUser = () => {
     }
   };
 
+  const userLogout = () => {
+    localStorage.removeItem('accessToken');
+    setUserToken((prev) => ({ ...prev, accessToken: '' }));
+    router.push('/auth/login');
+  };
+
   const userEmailCheck = async (email: string, retry?: boolean) => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -120,6 +126,7 @@ export const useUser = () => {
 
   return {
     userLogin,
+    userLogout,
     userEmailCheck,
     userEmailVerification,
     userSignUp,

--- a/src/stores/user/userInfo.ts
+++ b/src/stores/user/userInfo.ts
@@ -1,0 +1,8 @@
+import { atom } from 'jotai';
+
+import { UserDetail } from '@/apis/user/get';
+
+export const userInfoAtom = atom<UserDetail>({
+  email: '',
+  nickname: '',
+});


### PR DESCRIPTION
- 상단 헤더 우측의 프로필을 눌렀을 때 기능 구현
- 유저 이메일, 닉네임 불러오기
- 닉네임 변경 기능
- 로그아웃 기능
- 회원탈퇴는 아직 안됨

### 참고
- 프로필 아이콘은 아래의 규칙을 따릅니다.
![image](https://github.com/user-attachments/assets/d126e205-7d3c-4bcf-a312-eccf6fc2a565)
