### PR TITLE
[Fix] QA 0.9.3 반영

### DIFF
--- a/src/apis/auth/constants.ts
+++ b/src/apis/auth/constants.ts
@@ -1,8 +1,7 @@
 export const LOGIN_ERROR_MESSAGE: Record<string, string> = {
-  invalid_request: '올바른 이메일 주소를 입력해 주세요.', // 회원가입, 로그인
-  already_exist_email: '이미 가입되어있는 이메일입니다.', // 회원가입, 이메일 인증
-  invalid_password: '비밀번호를 다시 확인해 주세요.', // 회원가입
+  invalid_request: '올바른 이메일 주소를 입력해 주세요.', // 회원가입, 로그인 시 이메일 주소 포맷 유효성 검사 실패
+  already_exist_email: '이미 등록된 이메일입니다.', // 회원가입, 이메일 인증 시 이메일 기존재
+  invalid_password: '비밀번호를 다시 확인해 주세요.', // 회원가입, 로그인 시 패스워드 포맷 유효성 검사 실패
   incorrect_password: '비밀번호를 다시 확인해 주세요.', // 회원가입
-  incorrect_credentials: '이메일 또는 비밀번호를 다시 확인해 주세요', // 로그인
-  resource_not_found: '올바른 이메일 주소를 입력해 주세요.',
+  incorrect_credentials: '이메일 또는 비밀번호를 다시 확인해 주세요.', // 로그인 시 이메일이 존재하지 않거나 패스워드가 다른 경우
 };

--- a/src/apis/review/post.ts
+++ b/src/apis/review/post.ts
@@ -14,7 +14,7 @@ export const addScore = async (body: ScoreRequest) => {
 
 export interface ReviewProject {
   content: string;
-  projectId: number;
+  projectId: number | null;
 }
 
 export interface HighlightsRequest {

--- a/src/app/(with-navigation)/dashboards/page.tsx
+++ b/src/app/(with-navigation)/dashboards/page.tsx
@@ -50,7 +50,7 @@ export default function DashboardPage() {
           week: 'current',
           isChecked: false,
           todo: todo.content,
-          id: String(todo.id),
+          id: todo.id,
           isMoved: false,
         };
       }),

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,3 +1,5 @@
+import TextLogo from '@/components/icons/TextLogo';
+
 export default function AuthLayout({
   children,
 }: Readonly<{
@@ -6,6 +8,7 @@ export default function AuthLayout({
   return (
     <div className="w-full h-dvh flex justify-center pt-60 bg-surface-foreground">
       <div className="flex flex-col items-center">
+        <TextLogo />
         <main>{children}</main>
       </div>
     </div>

--- a/src/app/auth/login/components.tsx
+++ b/src/app/auth/login/components.tsx
@@ -39,7 +39,7 @@ const LoginComponents = () => {
   };
 
   const isLoginDisabled = useMemo(() => {
-    return !formData.email || formData.password.length < 8;
+    return !formData.email || !formData.password;
   }, [formData.email, formData.password]);
 
   return (

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,16 +1,11 @@
-import TextLogo from '@/components/icons/TextLogo';
-
 import LoginComponents from './components';
 
 const LoginPage = () => {
   return (
-    <div className="w-[25rem] pt-12 flex flex-col items-center gap-24">
-      <div className="flex flex-col items-center gap-2">
-        <h1 className="font-head-24 text-text-strong">
-          회고를 위한 가장 쉬운 선택
-        </h1>
-        <TextLogo />
-      </div>
+    <div className="w-[25rem] pt-11 flex flex-col items-center gap-9">
+      <h1 className="font-head-24 text-text-strong">
+        회고를 위한 가장 쉬운 선택
+      </h1>
 
       <LoginComponents />
     </div>

--- a/src/app/review/_components/add-button/AddButton.tsx
+++ b/src/app/review/_components/add-button/AddButton.tsx
@@ -42,7 +42,7 @@ export const AddButton = ({ category }: Props) => {
         setCurrentTodoList((prev) => [
           ...prev,
           {
-            id: `current-${getRandomNumber()}`,
+            id: -Math.abs(getRandomNumber()),
             week: weekInfo as WeekType,
             isChecked: false,
             todo: '',
@@ -53,7 +53,7 @@ export const AddButton = ({ category }: Props) => {
         setNextTodoList((prev) => [
           ...prev,
           {
-            id: `next-${getRandomNumber()}`,
+            id: -Math.abs(getRandomNumber()),
             week: weekInfo as WeekType,
             isChecked: false,
             todo: '',

--- a/src/app/review/_components/current-week-review/CurrentWeekReviewContainer.tsx
+++ b/src/app/review/_components/current-week-review/CurrentWeekReviewContainer.tsx
@@ -15,6 +15,7 @@ import {
   initialLowLightListAtom,
   lowLightListAtom,
   pageButtonStatesAtom,
+  reviewStepAtom,
 } from '../../stores';
 import { ReviewType } from '../../types';
 import { CurrentWeekReviewItem } from './CurrentWeekReviewItem';
@@ -40,6 +41,7 @@ export const CurrentWeekReviewContainer = ({
 
   const setPageButtonStates = useSetAtom(pageButtonStatesAtom);
   const disabledClickAttempt = useAtomValue(disabledClickAttemptAtom);
+  const reviewStep = useAtomValue(reviewStepAtom);
 
   const [projectList, setProjectList] = useState<DropdownItem[]>([]);
 
@@ -62,6 +64,7 @@ export const CurrentWeekReviewContainer = ({
       );
     }
   };
+
 
   const selectProject = (item: DropdownItem, reviewId: string | number) => {
     const selectedItem = {
@@ -98,21 +101,25 @@ export const CurrentWeekReviewContainer = ({
   };
 
   useEffect(() => {
-    if (category === 'highLight') {
+    if (reviewStep === 2) {
       (async () => {
         const response = await getHighlightList(currentWeekInfo);
-        setInitialHighLightList(response.highlights);
-        setHighLightList(response.highlights);
+        if (response?.highlights.length > 0) {
+          setInitialHighLightList(response.highlights);
+          setHighLightList(response.highlights);
+        }
       })();
     } else {
       (async () => {
         const response = await getLowlightList(currentWeekInfo);
-        setInitialLowLightList(response.lowlights);
-        setLowLightList(response.lowlights);
+        if (response?.lowlights.length > 0) {
+          setInitialLowLightList(response.lowlights);
+          setLowLightList(response.lowlights);
+        }
       })();
     }
   }, [
-    category,
+    reviewStep,
     setHighLightList,
     setInitialHighLightList,
     setInitialLowLightList,

--- a/src/app/review/_components/current-week-review/CurrentWeekReviewContainer.tsx
+++ b/src/app/review/_components/current-week-review/CurrentWeekReviewContainer.tsx
@@ -128,7 +128,7 @@ export const CurrentWeekReviewContainer = ({
         value: el.title,
       }));
 
-      setProjectList([INITIAL_PROJECT, ...newList]);
+      setProjectList(newList);
     })();
   }, [setProjectList]);
 
@@ -201,10 +201,4 @@ export const CurrentWeekReviewContainer = ({
           ))}
     </div>
   );
-};
-
-const INITIAL_PROJECT: DropdownItem = {
-  id: 0,
-  name: '프로젝트 선택',
-  value: '프로젝트 선택',
 };

--- a/src/app/review/_components/current-week-review/CurrentWeekReviewContainer.tsx
+++ b/src/app/review/_components/current-week-review/CurrentWeekReviewContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { getProjectTitleList } from '@/apis/projects/get';
 import { getHighlightList, getLowlightList } from '@/apis/review/get';
@@ -15,6 +15,7 @@ import {
   initialLowLightListAtom,
   lowLightListAtom,
   pageButtonStatesAtom,
+  projectListAtom,
   reviewStepAtom,
 } from '../../stores';
 import { ReviewType } from '../../types';
@@ -43,7 +44,7 @@ export const CurrentWeekReviewContainer = ({
   const disabledClickAttempt = useAtomValue(disabledClickAttemptAtom);
   const reviewStep = useAtomValue(reviewStepAtom);
 
-  const [projectList, setProjectList] = useState<DropdownItem[]>([]);
+  const [projectList, setProjectList] = useAtom(projectListAtom);
 
   const writeReview = (value: string, id: string | number) => {
     if (category === 'highLight') {
@@ -64,7 +65,6 @@ export const CurrentWeekReviewContainer = ({
       );
     }
   };
-
 
   const selectProject = (item: DropdownItem, reviewId: string | number) => {
     const selectedItem = {

--- a/src/app/review/_components/current-week-review/CurrentWeekReviewItem.tsx
+++ b/src/app/review/_components/current-week-review/CurrentWeekReviewItem.tsx
@@ -52,7 +52,7 @@ export const CurrentWeekReviewItem = ({
             initialItem={
               project && project.content !== ''
                 ? project.content
-                : '프로젝트 선택'
+                : '관련 프로젝트 (선택)'
             }
             onSelect={onSelect}
           />

--- a/src/app/review/_components/weekly-memo/WeeklyMemo.tsx
+++ b/src/app/review/_components/weekly-memo/WeeklyMemo.tsx
@@ -41,6 +41,7 @@ const WeeklyMemo = () => {
           memo={memo.content}
           date={memo.updatedAt}
           disabledEditor
+          isBookmark={memo.isMarked}
         />
       ))}
     </div>

--- a/src/app/review/step1/_components/achievement/Score.tsx
+++ b/src/app/review/step1/_components/achievement/Score.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { getReviewId } from '@/apis/review/get';
 import { addScore } from '@/apis/review/post';
 import {
+  disabledClickAttemptAtom,
   pageButtonStatesAtom,
   reviewIdAtom,
   scoreAtom,
@@ -17,6 +18,8 @@ const { year, month, week } = getCurrentWeek();
 
 export const Score = () => {
   const setPageButtonStates = useSetAtom(pageButtonStatesAtom);
+  const setDisabledClickAttempt = useSetAtom(disabledClickAttemptAtom);
+
   const [selectedScore, setSelectedScore] = useAtom(scoreAtom);
   const [reviewId, setReviewId] = useAtom(reviewIdAtom);
 
@@ -41,6 +44,7 @@ export const Score = () => {
   const onClickPickScore = async (count: number) => {
     setSelectedScore(count);
     setPageButtonStates((prev) => ({ ...prev, step1: true }));
+    setDisabledClickAttempt((prev) => ({ ...prev, step1: false }));
 
     if (reviewId) return;
 

--- a/src/app/review/step1/_components/achievement/Score.tsx
+++ b/src/app/review/step1/_components/achievement/Score.tsx
@@ -22,12 +22,21 @@ export const Score = () => {
 
   useEffect(() => {
     (async () => {
-      const reviewIdResponse = await getReviewId({ year, month, week });
+      try {
+        const reviewIdResponse = await getReviewId({ year, month, week });
 
-      setReviewId(reviewIdResponse.id);
-      setSelectedScore(reviewIdResponse.like);
+        setReviewId(reviewIdResponse?.id);
+        setSelectedScore(reviewIdResponse?.like);
+
+        setPageButtonStates((prev) => ({
+          ...prev,
+          step1: !!reviewIdResponse?.id,
+        }));
+      } catch (error) {
+        setPageButtonStates((prev) => ({ ...prev, step1: false }));
+      }
     })();
-  }, [reviewId, setReviewId, setSelectedScore]);
+  }, [reviewId, setPageButtonStates, setReviewId, setSelectedScore]);
 
   const onClickPickScore = async (count: number) => {
     setSelectedScore(count);
@@ -43,8 +52,9 @@ export const Score = () => {
           month,
           week,
         },
-        like: selectedScore,
+        like: count,
       });
+
       setReviewId(response.id);
     } catch (err) {
       console.log(err);

--- a/src/app/review/step1/_components/achievement/Score.tsx
+++ b/src/app/review/step1/_components/achievement/Score.tsx
@@ -11,14 +11,11 @@ import {
   scoreAtom,
 } from '@/app/review/stores';
 import ScorePicker from '@/components/score-picker/ScorePicker';
-import useToast from '@/hooks/useToast';
 import { getCurrentWeek } from '@/utils/date';
 
 const { year, month, week } = getCurrentWeek();
 
 export const Score = () => {
-  const { addToast } = useToast();
-
   const setPageButtonStates = useSetAtom(pageButtonStatesAtom);
   const [selectedScore, setSelectedScore] = useAtom(scoreAtom);
   const [reviewId, setReviewId] = useAtom(reviewIdAtom);
@@ -50,10 +47,7 @@ export const Score = () => {
       });
       setReviewId(response.id);
     } catch (err) {
-      addToast({
-        message: '다시 시도해 주세요.',
-        iconType: 'error',
-      });
+      console.log(err);
     }
   };
 

--- a/src/app/review/step1/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step1/_components/paging-button/PagingButton.tsx
@@ -97,10 +97,7 @@ export const PagingButton = () => {
         deleteTodo(newDeleteCurrentTodos), // 이번주할일 삭제
         deleteTodo(newDeleteNextTodos), // 다음주할일 삭제
       ]);
-      addToast({
-        iconType: 'success',
-        message: '임시저장 되었습니다.',
-      });
+
       setReviewStep(2);
       return responses;
     } catch (error) {

--- a/src/app/review/step1/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step1/_components/paging-button/PagingButton.tsx
@@ -72,18 +72,18 @@ export const PagingButton = () => {
     const newNextTodos = postNextTodos.map((el) => ({ content: el.todo }));
 
     const newPutCurrentTodos = putCurrentTodos.map((el) => ({
-      id: Number(el.id),
+      id: el.id,
       content: el.todo,
       status: el.isChecked ? 'DONE' : 'ONGOING',
     }));
     const newPutNextTodos = putNextTodos.map((el) => ({
-      id: Number(el.id),
+      id: el.id,
       content: el.todo,
       status: el.isChecked ? 'DONE' : 'ONGOING',
     }));
 
-    const newDeleteCurrentTodos = deleteCurrentTodos.map((el) => el.id);
-    const newDeleteNextTodos = deleteNextTodos.map((el) => el.id);
+    const newDeleteCurrentTodos = deleteCurrentTodos.map((el) => String(el.id));
+    const newDeleteNextTodos = deleteNextTodos.map((el) => String(el.id));
 
     try {
       const responses = await Promise.all([

--- a/src/app/review/step1/_components/todo/ListItem.tsx
+++ b/src/app/review/step1/_components/todo/ListItem.tsx
@@ -31,7 +31,7 @@ export const ListItem = ({
           placeholder="할 일을 입력해 주세요"
         />
       ) : (
-        <NextTodoInput value={todo} onChange={setTodo} />
+        <NextTodoInput id={id} value={todo} onChange={setTodo} />
       )}
       <div className="flex items-center gap-2">
         <MoveNextButton week={week} id={id} isMoved={isMoved} />

--- a/src/app/review/step1/_components/todo/ListItem.tsx
+++ b/src/app/review/step1/_components/todo/ListItem.tsx
@@ -22,11 +22,13 @@ export const ListItem = ({
     <div className="h-12 flex items-center">
       {week === 'current' ? (
         <CheckboxInput
+          id={id}
           value={todo}
           onChange={setTodo}
           checked={isChecked}
           onClickCheckbox={setIsChecked}
           category="review"
+          placeholder="할 일을 입력해 주세요"
         />
       ) : (
         <NextTodoInput value={todo} onChange={setTodo} />

--- a/src/app/review/step1/_components/todo/NextTodoInput.tsx
+++ b/src/app/review/step1/_components/todo/NextTodoInput.tsx
@@ -29,6 +29,7 @@ export const NextTodoInput = ({ value, onChange }: Props) => {
         onChange={(e) => onChange?.(e.currentTarget.value)}
         onFocus={() => setIsEditing(true)}
         onBlur={() => setIsEditing(false)}
+        placeholder="할 일을 입력해 주세요"
       />
     </div>
   );

--- a/src/app/review/step1/_components/todo/NextTodoInput.tsx
+++ b/src/app/review/step1/_components/todo/NextTodoInput.tsx
@@ -9,9 +9,10 @@ interface Props {
   onChange?: (value: string) => void;
   onBlur?: () => void;
   width?: string;
+  id: number;
 }
 
-export const NextTodoInput = ({ value, onChange }: Props) => {
+export const NextTodoInput = ({ id, value, onChange }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
 
   return (
@@ -30,6 +31,7 @@ export const NextTodoInput = ({ value, onChange }: Props) => {
         onFocus={() => setIsEditing(true)}
         onBlur={() => setIsEditing(false)}
         placeholder="할 일을 입력해 주세요"
+        autoFocus={id < 1}
       />
     </div>
   );

--- a/src/app/review/step1/_components/todo/TodoList.tsx
+++ b/src/app/review/step1/_components/todo/TodoList.tsx
@@ -109,7 +109,6 @@ export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
   const todoList = useMemo(() => {
     return week === 'current' ? currentTodoList : nextTodoList;
   }, [currentTodoList, nextTodoList, week]);
-  console.log(currentTodoList);
 
   return (
     <div className="flex flex-col">

--- a/src/app/review/step1/_components/todo/TodoList.tsx
+++ b/src/app/review/step1/_components/todo/TodoList.tsx
@@ -48,7 +48,7 @@ export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
           week: 'current',
           isChecked: el.status === 'DONE',
           todo: el.content,
-          id: String(el.id),
+          id: el.id,
         }));
 
         setCurrentTodoList(newList);
@@ -62,7 +62,7 @@ export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
           week: 'next',
           isChecked: el.status === 'DONE',
           todo: el.content,
-          id: String(el.id),
+          id: el.id,
         }));
 
         setNextTodoList(newList);
@@ -78,7 +78,7 @@ export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
     week,
   ]);
 
-  const onChangeText = (id: string, val: string) => {
+  const onChangeText = (id: number, val: string) => {
     if (week === 'current') {
       setCurrentTodoList((prev) =>
         prev.map((item) => (item.id === id ? { ...item, todo: val } : item)),
@@ -90,7 +90,7 @@ export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
     }
   };
 
-  const onToggleChecked = (id: string) => {
+  const onToggleChecked = (id: number) => {
     if (week === 'current') {
       setCurrentTodoList((prev) =>
         prev.map((item) =>
@@ -109,6 +109,7 @@ export const TodoList = ({ week }: Pick<TodoListItem, 'week'>) => {
   const todoList = useMemo(() => {
     return week === 'current' ? currentTodoList : nextTodoList;
   }, [currentTodoList, nextTodoList, week]);
+  console.log(currentTodoList);
 
   return (
     <div className="flex flex-col">

--- a/src/app/review/step2/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step2/_components/paging-button/PagingButton.tsx
@@ -41,13 +41,15 @@ export const PagingButton = () => {
     }
     const newPostHighlights = postHighlights.map((el) => ({
       content: el.content,
-      projectId: Number(el.project?.id) ?? null,
+      projectId: Number(el.project?.id) !== 0 ? Number(el.project?.id) : null,
     }));
+
+    console.log(newPostHighlights);
 
     const newPutHighlights = putHighlights.map((el) => ({
       id: el.id,
       content: el.content,
-      projectId: Number(el.project?.id) ?? null,
+      projectId: Number(el.project?.id) !== 0 ? Number(el.project?.id) : null,
     }));
 
     try {

--- a/src/app/review/step2/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step2/_components/paging-button/PagingButton.tsx
@@ -44,8 +44,6 @@ export const PagingButton = () => {
       projectId: Number(el.project?.id) !== 0 ? Number(el.project?.id) : null,
     }));
 
-    console.log(newPostHighlights);
-
     const newPutHighlights = putHighlights.map((el) => ({
       id: el.id,
       content: el.content,

--- a/src/app/review/step2/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step2/_components/paging-button/PagingButton.tsx
@@ -84,11 +84,6 @@ export const PagingButton = () => {
           : []),
       ]);
 
-      addToast({
-        message: '임시저장 되었습니다.',
-        iconType: 'success',
-      });
-
       setReviewStep(3);
     } catch (error) {
       addToast({

--- a/src/app/review/step3/_components/paging-button/PagingButton.tsx
+++ b/src/app/review/step3/_components/paging-button/PagingButton.tsx
@@ -42,13 +42,13 @@ export const PagingButton = () => {
 
     const newPostLowlights = postLowlights.map((el) => ({
       content: el.content,
-      projectId: Number(el.project?.id) ?? null,
+      projectId: Number(el.project?.id) !== 0 ? Number(el.project?.id) : null,
     }));
 
     const newPutLowlights = putLowlights.map((el) => ({
       id: el.id,
       content: el.content,
-      projectId: Number(el.project?.id) ?? null,
+      projectId: Number(el.project?.id) !== 0 ? Number(el.project?.id) : null,
     }));
 
     try {

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -1,5 +1,7 @@
 import { atom } from 'jotai';
 
+import { DropdownItem } from '@/components/dropdown/Dropdown';
+
 import { MemoItem, ReviewListItem, TodoListItem } from './types';
 
 export const scoreAtom = atom(0);
@@ -50,3 +52,5 @@ export const lastHighLightListAtom = atom<ReviewListItem[]>([]);
 export const lastLowLightListAtom = atom<ReviewListItem[]>([]);
 
 export const memoListAtom = atom<MemoItem[]>([]);
+
+export const projectListAtom = atom<DropdownItem[]>([]);

--- a/src/app/review/stores.ts
+++ b/src/app/review/stores.ts
@@ -29,13 +29,22 @@ export const initialNextTodoListAtom = atom<TodoListItem[]>([]);
 export const currentTodoListAtom = atom<TodoListItem[]>([]);
 export const nextTodoListAtom = atom<TodoListItem[]>([]);
 
+const InitialReviewItem = {
+  id: 0,
+  content: '',
+};
+
 // get한 하이라이트 / 로우라이트 list
-export const initialHighLightListAtom = atom<ReviewListItem[]>([]);
-export const initialLowLightListAtom = atom<ReviewListItem[]>([]);
+export const initialHighLightListAtom = atom<ReviewListItem[]>([
+  InitialReviewItem,
+]);
+export const initialLowLightListAtom = atom<ReviewListItem[]>([
+  InitialReviewItem,
+]);
 
 // 수정된 하이라이트 / 로우라이트 list
-export const highLightListAtom = atom<ReviewListItem[]>([]);
-export const lowLightListAtom = atom<ReviewListItem[]>([]);
+export const highLightListAtom = atom<ReviewListItem[]>([InitialReviewItem]);
+export const lowLightListAtom = atom<ReviewListItem[]>([InitialReviewItem]);
 
 export const lastHighLightListAtom = atom<ReviewListItem[]>([]);
 export const lastLowLightListAtom = atom<ReviewListItem[]>([]);

--- a/src/app/review/types.ts
+++ b/src/app/review/types.ts
@@ -10,7 +10,7 @@ export interface TodoListItem {
   week: WeekType;
   isChecked: boolean;
   todo: string;
-  id: string;
+  id: number;
   isMoved?: boolean;
 }
 

--- a/src/components/action-sheets/Container.tsx
+++ b/src/components/action-sheets/Container.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import type { PropsWithChildren } from 'react';
+import { createPortal } from 'react-dom';
 
 import { Button } from '@/types/button';
 import { cn } from '@/utils/tailwind';
@@ -24,8 +27,11 @@ const RightActionSheetContainer = ({
   disableAnimation,
 }: PropsWithChildren<Props>) => {
   if (!isOpen) return null;
+  if (typeof document === 'undefined') {
+    return null;
+  }
 
-  return (
+  return createPortal(
     <div className="w-screen h-screen fixed z-30">
       <div className="w-screen h-screen relative">
         {/* background dimmer */}
@@ -84,7 +90,8 @@ const RightActionSheetContainer = ({
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/src/components/action-sheets/Container.tsx
+++ b/src/components/action-sheets/Container.tsx
@@ -27,6 +27,7 @@ const RightActionSheetContainer = ({
   disableAnimation,
 }: PropsWithChildren<Props>) => {
   if (!isOpen) return null;
+
   if (typeof document === 'undefined') {
     return null;
   }

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -113,6 +113,7 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
             text: '저장',
             onClick: enrollProject,
             buttonStyle: 'primary',
+            disabled: !title || !dateRange.start || !dateRange.end,
           },
         ]}
       >

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -40,6 +40,17 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
     setDescription('');
   };
 
+  const resetProject = async () => {
+    const response = await getProjectTitleList();
+    const newList = response?.projects.map((el) => ({
+      id: el.id,
+      name: el.title,
+      value: el.title,
+    }));
+
+    setProjectList(newList);
+  };
+
   const enrollProject = async () => {
     const [startYear, startMonth, startDay] = dateRange.start.split('.');
     const [endYear, endMonth, endDay] = dateRange.end.split('.');
@@ -54,15 +65,7 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
 
     try {
       await addProject(body);
-
-      const response = await getProjectTitleList();
-      const newList = response?.projects.map((el) => ({
-        id: el.id,
-        name: el.title,
-        value: el.title,
-      }));
-
-      setProjectList(newList);
+      await resetProject();
 
       addToast({
         message: '프로젝트 내용이 저장되었어요.',

--- a/src/components/action-sheets/create-project/CreateProjectSheet.tsx
+++ b/src/components/action-sheets/create-project/CreateProjectSheet.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useSetAtom } from 'jotai';
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
 
+import { getProjectTitleList } from '@/apis/projects/get';
 import { addProject } from '@/apis/projects/post';
+import { projectListAtom } from '@/app/review/stores';
 import DateRangeInput from '@/components/inputs/date/DateRangeInput';
 import Input from '@/components/inputs/input/Input';
 import LineInput from '@/components/inputs/line/LineInput';
@@ -20,6 +23,8 @@ interface Props {
 
 const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
   const { addToast } = useToast();
+
+  const setProjectList = useSetAtom(projectListAtom);
 
   const [title, setTitle] = useState('');
   const [dateRange, setDateRange] = useState({ start: '', end: '' });
@@ -49,6 +54,16 @@ const CreateProjectSheet = ({ isOpen, closeSheet }: Props) => {
 
     try {
       await addProject(body);
+
+      const response = await getProjectTitleList();
+      const newList = response?.projects.map((el) => ({
+        id: el.id,
+        name: el.title,
+        value: el.title,
+      }));
+
+      setProjectList(newList);
+
       addToast({
         message: '프로젝트 내용이 저장되었어요.',
         iconType: 'success',

--- a/src/components/memo/Memo.tsx
+++ b/src/components/memo/Memo.tsx
@@ -61,7 +61,12 @@ const Memo = ({
           )}
         </div>
 
-        <MemoBottom id={id} isBookmark={isBookmark} date={date} />
+        <MemoBottom
+          id={id}
+          isBookmark={isBookmark}
+          date={date}
+          disabledEditor={disabledEditor}
+        />
       </div>
 
       <TextEditorModal

--- a/src/components/memo/MemoBottom.tsx
+++ b/src/components/memo/MemoBottom.tsx
@@ -15,7 +15,8 @@ const MemoBottom = ({
   isBookmark,
   date,
   id,
-}: Pick<MemoItem, 'isBookmark' | 'date' | 'id'>) => {
+  disabledEditor = false,
+}: Pick<MemoItem, 'isBookmark' | 'date' | 'id' | 'disabledEditor'>) => {
   const [isMark, setIsMark] = useState(isBookmark);
   const setMemoList = useSetAtom(memoListAtom);
 
@@ -46,19 +47,22 @@ const MemoBottom = ({
       <p className="font-body-12 text-text-neutral">
         {getMemoCreateDate(date)}
       </p>
-      <button
-        type="button"
-        onClick={async (e) => {
-          e.stopPropagation();
-          await onClickBookmark();
-        }}
-      >
-        <BookmarkIcon
-          fill={isMark ? colors.line.focus : 'none'}
-          stroke={isMark ? colors.line.focus : colors.text.neutral}
-          className="cursor-pointer"
-        />
-      </button>
+      {((disabledEditor && isMark) || !disabledEditor) && (
+        <button
+          type="button"
+          onClick={async (e) => {
+            e.stopPropagation();
+            await onClickBookmark();
+          }}
+          disabled={disabledEditor}
+        >
+          <BookmarkIcon
+            fill={isMark ? colors.line.focus : 'none'}
+            stroke={isMark ? colors.line.focus : colors.text.neutral}
+            className={disabledEditor ? 'cursor-default' : 'cursor-pointer'}
+          />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/modal/text-editor/index.tsx
+++ b/src/components/modal/text-editor/index.tsx
@@ -85,13 +85,14 @@ const TextEditorModal = ({
             }}
           />
         </div>
-
-        <TextEditorBottom
-          id={id}
-          isBookmark={isBookmark}
-          updatedAt={lastUpdated}
-          deleteMemo={onClickDelete}
-        />
+        {!disabledEditor && (
+          <TextEditorBottom
+            id={id}
+            isBookmark={isBookmark}
+            updatedAt={lastUpdated}
+            deleteMemo={onClickDelete}
+          />
+        )}
       </div>
     </Modal>
   );

--- a/src/components/modal/text-editor/index.tsx
+++ b/src/components/modal/text-editor/index.tsx
@@ -85,6 +85,7 @@ const TextEditorModal = ({
             }}
           />
         </div>
+
         {!disabledEditor && (
           <TextEditorBottom
             id={id}

--- a/src/components/text-editor/MenuBar.tsx
+++ b/src/components/text-editor/MenuBar.tsx
@@ -24,54 +24,63 @@ const MenuBar = ({ editor }: Props) => {
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleBold().run()}
+        disabled={!editor.isEditable}
       >
         <BoldIcon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleItalic().run()}
+        disabled={!editor.isEditable}
       >
         <ItalicIcon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleUnderline().run()}
+        disabled={!editor.isEditable}
       >
         <UnderlineIcon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleCode().run()}
+        disabled={!editor.isEditable}
       >
         <CodeBlockIcon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        disabled={!editor.isEditable}
       >
         <Header1Icon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        disabled={!editor.isEditable}
       >
         <Header2Icon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+        disabled={!editor.isEditable}
       >
         <Header3Icon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        disabled={!editor.isEditable}
       >
         <OrderedListIcon size={24} />
       </button>
       <button
         className="w-6 h-6"
         onClick={() => editor.chain().focus().toggleBulletList().run()}
+        disabled={!editor.isEditable}
       >
         <UnorderedListIcon size={24} />
       </button>

--- a/src/hooks/useTodosApi.tsx
+++ b/src/hooks/useTodosApi.tsx
@@ -20,14 +20,14 @@ export const useTodosApi = () => {
   };
 
   // 비교 배열엔 없으나 새로운 배열에서 생긴 id
-  const getNewIds = (list1: string[], list2: string[]) => {
+  const getNewIds = (list1: number[], list2: number[]) => {
     const differentIdList = list1.filter((id) => !list2.includes(id));
 
     return differentIdList;
   };
 
   // 초기 배열, 새로운 배열에서 동일한 id
-  const getPutIds = (list1: string[], list2: string[]) => {
+  const getPutIds = (list1: number[], list2: number[]) => {
     const commonIdList = list1.filter((id) => list2.includes(id));
 
     return commonIdList;

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,5 +1,5 @@
 export const getRandomNumber = () => {
   const initialString = Math.random().toString();
   const result = initialString.split('.')[1];
-  return result;
+  return Number(result);
 };


### PR DESCRIPTION
### auth
- layout에 text logo 추가
- 로그인 및 계정 생성 관련 toast 에러 코드 백엔드 수정본 반영
- 로그인 : 이메일 1자 + 비밀번호 1자 입력 시 로그인 버튼 활성화되도록 수정

### 회고
- step1 : 회고 id 없어도 page button 활성화되던 이슈 수정
- step1 : 만족도 클릭 후 error 발생 시 toast 뜨던 부분 제거
- step1 : 만족도 클릭 안 하고 다음 버튼 클릭 시 에러 텍스트 노축되는데, 다시 만족도 클릭 시 에러 텍스트 사라지도록 수정
- step1 : todo에 있던 console log 제거
- step1 : todo 추가 버튼 클릭 시 auto focus 추가
- step1 : todo id를 number 타입으로 변경
- step2/3 : 프로젝트 선택 드랍다운에서 '관련 프로젝트 선택' 항목 제거
- step2/3 : 프로젝트 생성 action sheet에 react portal 적용 (기존에 step 컴포넌트 내부에서 렌더링 되던 이슈)
- step2/3 : 하이라이트/로우라이트 default 하나 떠있도록 수정
- step2/3 : 하이라이트/로우라이트 projectId null 타입 추가 (프로젝트 선택하지 않았을 때 null로 전달)
- 다음 버튼 클릭 시 '임시 저장 되었습니다' toast 제거
- 메모 마크다운, 북마크, 삭제 클릭 안 되도록 수정. (북마크와 삭제의 경우 상세에서 노출되지 않음. isMarked인 경우 개요에서 북마크 표시)