### PR TITLE
[FIX] 마크다운 에디터 제거

### DIFF
--- a/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
+++ b/src/app/(with-navigation)/dashboards/_components/MemoList.tsx
@@ -8,7 +8,7 @@ import { memoListAtom } from '@/app/review/stores';
 import EmptyMemoImage from '@/assets/images/memo-empty.png';
 import PlusIcon from '@/components/icons/PlusIcon';
 import Memo from '@/components/memo/Memo';
-import TextEditorModal from '@/components/modal/text-editor';
+import MemoEditor from '@/components/modal/memo-editor/MemoEditor';
 import useToast from '@/hooks/useToast';
 import { displayWeekAtom } from '@/stores/week/displayWeek';
 import { CurrentWeek } from '@/types/currentWeek';
@@ -97,7 +97,7 @@ const MemoList = () => {
         </div>
       )}
 
-      <TextEditorModal
+      <MemoEditor
         isOpen={openTextEditor}
         onDismiss={() => {
           setOpenTextEditor(false);

--- a/src/app/(with-navigation)/history/_components/Category.tsx
+++ b/src/app/(with-navigation)/history/_components/Category.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { AllMemosResponse, getAllMemos } from '@/apis/memo/get';
 import { addNewMemo } from '@/apis/memo/post';
 import PlusIcon from '@/components/icons/PlusIcon';
-import TextEditorModal from '@/components/modal/text-editor';
+import MemoEditor from '@/components/modal/memo-editor/MemoEditor';
 import ToggleSwitch from '@/components/toggle-switch/ToggleSwitch';
 import { showOnlyBookmarkAtom } from '@/stores/bookmark/showOnlyBookmarkAtom';
 import { historyMemoListAtom, MemoList } from '@/stores/memos/memos';
@@ -114,7 +114,7 @@ const Category = () => {
         </button>
       )}
 
-      <TextEditorModal
+      <MemoEditor
         isOpen={openTextEditor}
         onDismiss={() => {
           setOpenTextEditor(false);

--- a/src/app/review/_components/last-week-review/LastWeekReviewItem.tsx
+++ b/src/app/review/_components/last-week-review/LastWeekReviewItem.tsx
@@ -1,5 +1,3 @@
-import { useRouter } from 'next/navigation';
-
 import { ReviewListItem } from '@/app/review/types';
 import CloseCircleIcon from '@/components/icons/CloseCircleIcon';
 import LinkIcon from '@/components/icons/LinkIcon';
@@ -18,8 +16,6 @@ export const LastWeekReviewItem = ({
   editable = false,
   onClickDelete,
 }: Props) => {
-  const router = useRouter();
-
   return (
     <div className="w-full">
       <div
@@ -33,7 +29,7 @@ export const LastWeekReviewItem = ({
         <div
           className={cn('flex', !editable && 'cursor-pointer')}
           onClick={() =>
-            !editable && router.push(`/project?project=${project.id}`)
+            !editable && window.open(`/project?project=${project.id}`)
           }
         >
           <LinkIcon size={36} />

--- a/src/components/action-sheets/project-detail/_components/RelatedReview.tsx
+++ b/src/components/action-sheets/project-detail/_components/RelatedReview.tsx
@@ -33,6 +33,7 @@ const RelatedReview = ({ type, review, week, last }: Props) => {
         <div className="w-full flex justify-end">
           <Link
             href={`/dashboards?year=${week.year}&month=${week.month}&week=${week.week}`}
+            target="_blank"
           >
             <div className="flex items-center gap-0.5 w-fit">
               <p className="font-body-13 text-text-strong">{`${week.month}월 ${week.week}주차`}</p>

--- a/src/components/memo/Memo.tsx
+++ b/src/components/memo/Memo.tsx
@@ -6,7 +6,7 @@ import { editMemo } from '@/apis/memo/put';
 import { MemoItem } from '@/app/review/types';
 import { cn } from '@/utils/tailwind';
 
-import TextEditorModal from '../modal/text-editor';
+import MemoEditor from '../modal/memo-editor/MemoEditor';
 import MemoBottom from './MemoBottom';
 
 const Memo = ({
@@ -58,10 +58,7 @@ const Memo = ({
         <div className="w-full h-full pr-1 break-keep overflow-hidden whitespace-pre-wrap line-clamp-4">
           {!!title && <p className="font-title-14 text-text-strong">{title}</p>}
           {!!memo && (
-            <p
-              className="font-body-14 text-text-strong"
-              dangerouslySetInnerHTML={{ __html: textValue }}
-            />
+            <p className="font-body-14 text-text-strong">{textValue}</p>
           )}
         </div>
 
@@ -73,8 +70,8 @@ const Memo = ({
         />
       </div>
 
-      <TextEditorModal
-        disabledEditor={disabledEditor}
+      <MemoEditor
+        readonly={disabledEditor}
         isOpen={showMemo}
         onDismiss={onClickCloseModal}
         onSaveText={async (val) => {
@@ -82,7 +79,7 @@ const Memo = ({
           setTextValue(val);
         }}
         value={textValue}
-        id={id}
+        id={Number(id)}
         lastUpdated={date}
         isBookmark={isBookmark}
       />

--- a/src/components/modal/memo-editor/BottomMenu.tsx
+++ b/src/components/modal/memo-editor/BottomMenu.tsx
@@ -1,0 +1,74 @@
+import { useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+
+import { bookmarkMemo } from '@/apis/memo/put';
+import { memoListAtom } from '@/app/review/stores';
+import BookmarkIcon from '@/components/icons/BookmarkIcon';
+import colors from '@/styles/colors';
+import { getUpdatedDate } from '@/utils/date';
+
+interface Props {
+  id?: number;
+  lastUpdated?: string;
+  readonly?: boolean;
+  isBookmark?: boolean;
+}
+
+const BottomMenu = ({ id, lastUpdated, readonly, isBookmark }: Props) => {
+  const [isMarked, setIsMarked] = useState(isBookmark);
+  const setMemoList = useSetAtom(memoListAtom);
+
+  useEffect(() => {
+    setIsMarked(isBookmark);
+  }, [isBookmark]);
+
+  const changeBookmark = async () => {
+    try {
+      await bookmarkMemo(Number(id));
+    } catch (error) {
+      console.error('fail to bookmark memo', error);
+    }
+  };
+
+  const onClickBookmark = async () => {
+    await changeBookmark();
+    setIsMarked((prev) => !prev);
+    setMemoList((prev) =>
+      prev.map((memo) =>
+        memo.id === String(id)
+          ? { ...memo, isBookmark: !memo.isBookmark }
+          : memo,
+      ),
+    );
+  };
+
+  return (
+    <div className="flex items-center justify-between p-[1.625rem]">
+      {lastUpdated ? (
+        <p className="font-body-12 text-text-normal">
+          {getUpdatedDate(lastUpdated)}
+        </p>
+      ) : (
+        <div />
+      )}
+
+      <button
+        type="button"
+        disabled={readonly}
+        onClick={async (e) => {
+          e.stopPropagation();
+          await onClickBookmark();
+        }}
+      >
+        <BookmarkIcon
+          size={20}
+          fill={isMarked ? colors.line.focus : 'none'}
+          stroke={isMarked ? colors.line.focus : colors.text.neutral}
+          className={readonly ? 'cursor-default' : 'cursor-pointer'}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default BottomMenu;

--- a/src/components/modal/memo-editor/MemoEditor.tsx
+++ b/src/components/modal/memo-editor/MemoEditor.tsx
@@ -1,0 +1,69 @@
+import { useRef, useState } from 'react';
+
+import ModalContainer, { ModalProps } from '../ModalContainer';
+import BottomMenu from './BottomMenu';
+import TopMenu from './TopMenu';
+
+interface Props extends ModalProps {
+  onSaveText: (text: string) => void;
+  value: string;
+  readonly?: boolean;
+  lastUpdated?: string;
+  id?: number;
+  isBookmark?: boolean;
+}
+
+const MemoEditor = ({
+  onSaveText,
+  value,
+  readonly = false,
+  lastUpdated,
+  id,
+  isBookmark,
+  ...rest
+}: Props) => {
+  const editorRef = useRef<HTMLTextAreaElement>(null);
+
+  const [input, setInput] = useState(value);
+
+  return (
+    <ModalContainer {...rest}>
+      <section className="flex flex-col justify-between">
+        <TopMenu
+          id={id}
+          readonly={readonly}
+          onDismiss={rest.onDismiss}
+          lastUpdated={lastUpdated}
+        />
+
+        <textarea
+          ref={editorRef}
+          className="w-full h-full px-6 py-4 resize-none outline-none font-body-14 text-text-strong min-h-[16.5rem] min-w-[28.5rem]"
+          name="memo"
+          id="memo"
+          autoFocus
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (
+              (e.ctrlKey && e.key === 'Enter') ||
+              (e.metaKey && e.key === 'Enter')
+            ) {
+              onSaveText(input);
+              rest.onDismiss?.();
+            }
+          }}
+        />
+
+        <BottomMenu
+          id={id}
+          lastUpdated={lastUpdated}
+          readonly={readonly}
+          isBookmark={isBookmark}
+        />
+      </section>
+    </ModalContainer>
+  );
+};
+
+export default MemoEditor;

--- a/src/components/modal/memo-editor/MemoEditor.tsx
+++ b/src/components/modal/memo-editor/MemoEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import ModalContainer, { ModalProps } from '../ModalContainer';
 import BottomMenu from './BottomMenu';
@@ -26,6 +26,10 @@ const MemoEditor = ({
 
   const [input, setInput] = useState(value);
 
+  useEffect(() => {
+    setInput(value);
+  }, [value]);
+
   return (
     <ModalContainer {...rest}>
       <section className="flex flex-col justify-between">
@@ -34,6 +38,7 @@ const MemoEditor = ({
           readonly={readonly}
           onDismiss={rest.onDismiss}
           lastUpdated={lastUpdated}
+          onSaveText={() => onSaveText(input)}
         />
 
         <textarea

--- a/src/components/modal/memo-editor/MemoEditor.tsx
+++ b/src/components/modal/memo-editor/MemoEditor.tsx
@@ -36,6 +36,11 @@ const MemoEditor = ({
   }, [value, isOpen]);
 
   const onClickBackground = () => {
+    if (readonly) {
+      onDismiss?.();
+      return;
+    }
+
     if (input !== value) {
       setShowExitAlert(true);
     } else {
@@ -63,7 +68,10 @@ const MemoEditor = ({
           autoFocus
           value={input}
           onChange={(e) => setInput(e.currentTarget.value)}
+          readOnly={readonly}
           onKeyDown={(e) => {
+            if (readonly) return;
+
             if (
               (e.ctrlKey && e.key === 'Enter') ||
               (e.metaKey && e.key === 'Enter')

--- a/src/components/modal/memo-editor/MemoEditor.tsx
+++ b/src/components/modal/memo-editor/MemoEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
+import Alert from '../Alert';
 import ModalContainer, { ModalProps } from '../ModalContainer';
 import BottomMenu from './BottomMenu';
 import TopMenu from './TopMenu';
@@ -20,25 +21,35 @@ const MemoEditor = ({
   lastUpdated,
   id,
   isBookmark,
-  ...rest
+  isOpen,
+  onDismiss,
 }: Props) => {
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
   const [input, setInput] = useState(value);
+  const [showExitAlert, setShowExitAlert] = useState(false);
 
   useEffect(() => {
-    if (!rest.isOpen) return;
+    if (!isOpen) return;
 
     setInput(value);
-  }, [value, rest.isOpen]);
+  }, [value, isOpen]);
+
+  const onClickBackground = () => {
+    if (input !== value) {
+      setShowExitAlert(true);
+    } else {
+      onDismiss?.();
+    }
+  };
 
   return (
-    <ModalContainer {...rest}>
+    <ModalContainer isOpen={isOpen} onDismiss={onClickBackground}>
       <section className="flex flex-col justify-between">
         <TopMenu
           id={id}
           readonly={readonly}
-          onDismiss={rest.onDismiss}
+          onDismiss={onDismiss}
           lastUpdated={lastUpdated}
           onSaveText={() => onSaveText(input)}
           hasChanges={input !== value}
@@ -58,7 +69,7 @@ const MemoEditor = ({
               (e.metaKey && e.key === 'Enter')
             ) {
               onSaveText(input);
-              rest.onDismiss?.();
+              onDismiss?.();
             }
           }}
           onFocus={(e) =>
@@ -76,6 +87,22 @@ const MemoEditor = ({
           isBookmark={isBookmark}
         />
       </section>
+
+      <Alert
+        isOpen={showExitAlert}
+        onDismiss={() => setShowExitAlert(false)}
+        title="메모를 저장하시겠어요?"
+        buttons={{
+          left: { text: '아니오', onClick: onDismiss },
+          right: {
+            text: '예',
+            onClick: () => {
+              onSaveText(input);
+              onDismiss?.();
+            },
+          },
+        }}
+      />
     </ModalContainer>
   );
 };

--- a/src/components/modal/memo-editor/MemoEditor.tsx
+++ b/src/components/modal/memo-editor/MemoEditor.tsx
@@ -27,8 +27,10 @@ const MemoEditor = ({
   const [input, setInput] = useState(value);
 
   useEffect(() => {
+    if (!rest.isOpen) return;
+
     setInput(value);
-  }, [value]);
+  }, [value, rest.isOpen]);
 
   return (
     <ModalContainer {...rest}>
@@ -39,6 +41,7 @@ const MemoEditor = ({
           onDismiss={rest.onDismiss}
           lastUpdated={lastUpdated}
           onSaveText={() => onSaveText(input)}
+          hasChanges={input !== value}
         />
 
         <textarea

--- a/src/components/modal/memo-editor/MemoEditor.tsx
+++ b/src/components/modal/memo-editor/MemoEditor.tsx
@@ -53,6 +53,12 @@ const MemoEditor = ({
               rest.onDismiss?.();
             }
           }}
+          onFocus={(e) =>
+            e.currentTarget.setSelectionRange(
+              e.currentTarget.value.length,
+              e.currentTarget.value.length,
+            )
+          }
         />
 
         <BottomMenu

--- a/src/components/modal/memo-editor/TopMenu.tsx
+++ b/src/components/modal/memo-editor/TopMenu.tsx
@@ -12,9 +12,16 @@ interface Props {
   readonly: boolean;
   lastUpdated?: string;
   onDismiss?: () => void;
+  onSaveText?: () => void;
 }
 
-const TopMenu = ({ id, readonly, lastUpdated, onDismiss }: Props) => {
+const TopMenu = ({
+  id,
+  readonly,
+  lastUpdated,
+  onDismiss,
+  onSaveText,
+}: Props) => {
   const setMemoList = useSetAtom(memoListAtom);
 
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);
@@ -52,7 +59,14 @@ const TopMenu = ({ id, readonly, lastUpdated, onDismiss }: Props) => {
           >
             삭제
           </button>
-          <button className="button-small button-primary" type="button">
+          <button
+            className="button-small button-primary"
+            type="button"
+            onClick={() => {
+              onSaveText?.();
+              onDismiss?.();
+            }}
+          >
             저장
           </button>
         </div>

--- a/src/components/modal/memo-editor/TopMenu.tsx
+++ b/src/components/modal/memo-editor/TopMenu.tsx
@@ -13,6 +13,7 @@ interface Props {
   lastUpdated?: string;
   onDismiss?: () => void;
   onSaveText?: () => void;
+  hasChanges?: boolean;
 }
 
 const TopMenu = ({
@@ -21,6 +22,7 @@ const TopMenu = ({
   lastUpdated,
   onDismiss,
   onSaveText,
+  hasChanges,
 }: Props) => {
   const setMemoList = useSetAtom(memoListAtom);
 
@@ -66,6 +68,7 @@ const TopMenu = ({
               onSaveText?.();
               onDismiss?.();
             }}
+            disabled={!hasChanges}
           >
             저장
           </button>

--- a/src/components/modal/memo-editor/TopMenu.tsx
+++ b/src/components/modal/memo-editor/TopMenu.tsx
@@ -45,7 +45,11 @@ const TopMenu = ({ id, readonly, lastUpdated, onDismiss }: Props) => {
         </p>
       ) : (
         <div className="flex gap-2">
-          <button className="button-small button-secondary" type="button">
+          <button
+            className="button-small button-secondary"
+            type="button"
+            onClick={() => setShowDeleteAlert(true)}
+          >
             삭제
           </button>
           <button className="button-small button-primary" type="button">

--- a/src/components/modal/memo-editor/TopMenu.tsx
+++ b/src/components/modal/memo-editor/TopMenu.tsx
@@ -1,0 +1,70 @@
+import { useSetAtom } from 'jotai';
+import { useState } from 'react';
+
+import { deleteMemo } from '@/apis/memo/delete';
+import { memoListAtom } from '@/app/review/stores';
+import CloseIcon from '@/components/icons/CloseIcon';
+
+import Alert from '../Alert';
+
+interface Props {
+  id?: number;
+  readonly: boolean;
+  lastUpdated?: string;
+  onDismiss?: () => void;
+}
+
+const TopMenu = ({ id, readonly, lastUpdated, onDismiss }: Props) => {
+  const setMemoList = useSetAtom(memoListAtom);
+
+  const [showDeleteAlert, setShowDeleteAlert] = useState(false);
+
+  const onClickDelete = async () => {
+    if (lastUpdated) {
+      try {
+        await deleteMemo(Number(id));
+        setMemoList((prev) => prev.filter((memo) => memo.id !== String(id)));
+        onDismiss?.();
+      } catch (error) {
+        console.error('fail to delete memo', error);
+      }
+    } else {
+      onDismiss?.();
+    }
+  };
+
+  return (
+    <div className="border-b border-b-line-assistive flex items-center justify-between px-6 py-[1.125rem]">
+      <button type="button" onClick={onDismiss}>
+        <CloseIcon size={20} />
+      </button>
+
+      {readonly ? (
+        <p className="font-body-14 text-text-neutral">
+          회고 중에는 메모 확인만 가능해요.
+        </p>
+      ) : (
+        <div className="flex gap-2">
+          <button className="button-small button-secondary" type="button">
+            삭제
+          </button>
+          <button className="button-small button-primary" type="button">
+            저장
+          </button>
+        </div>
+      )}
+
+      <Alert
+        isOpen={showDeleteAlert}
+        onDismiss={() => setShowDeleteAlert(false)}
+        title="정말로 삭제하시겠어요?"
+        buttons={{
+          left: { text: '취소' },
+          right: { text: '확인', onClick: onClickDelete },
+        }}
+      />
+    </div>
+  );
+};
+
+export default TopMenu;


### PR DESCRIPTION
기존에 존재하던 마크다운 에디터(`TextEditorModal`)를 제거하고, 새로운 메모 에디터(`MemoEditor`)를 작성했습니다.

저번 회의에서 나온 의견에 따르면 추후에 마크다운 에디터가 다시 도입될 가능성이 있어, 컴포넌트는 제거하지 않고 남겨뒀습니다.

이 외에 회고에서 주차 클릭 시, 리뷰에서 프로젝트 클릭 시 페이지 전환이 아닌, 새 창으로 열리도록 변경했습니다.